### PR TITLE
Add test exposing missing fee persistence

### DIFF
--- a/test/util/mock/MockPrepareReactor.sol
+++ b/test/util/mock/MockPrepareReactor.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {BaseReactor} from "../../../src/reactors/BaseReactor.sol";
+import {ResolvedOrder, SignedOrder} from "../../../src/base/ReactorStructs.sol";
+import {IPermit2} from "permit2/src/interfaces/IPermit2.sol";
+
+/// @notice Reactor exposing _prepare for testing memory behavior
+contract MockPrepareReactor is BaseReactor {
+    constructor(IPermit2 permit2_, address feeOwner) BaseReactor(permit2_, feeOwner) {}
+
+    function prepareOrders(ResolvedOrder[] memory orders) external returns (ResolvedOrder[] memory) {
+        _prepare(orders);
+        return orders;
+    }
+
+    function _resolve(SignedOrder calldata) internal pure override returns (ResolvedOrder memory) {
+        revert("unused");
+    }
+
+    function _transferInputTokens(ResolvedOrder memory, address) internal override {}
+}


### PR DESCRIPTION
## Summary
- expose `_prepare` via new `MockPrepareReactor` for testing
- add `test_base_prepareFeeOutputsVanishing` to demonstrate fee outputs disappear

## Testing
- `forge test --match-test prepareFeeOutputsVanishing -vv`
- `forge test --match-test test_base_executeBatchWithFee -vv`

------
https://chatgpt.com/codex/tasks/task_e_687beb9319d0832d8123ac5e1b701536