### PR TITLE
Add test demonstrating DAI permit2 unlimited approval

### DIFF
--- a/test/lib/Permit2DaiBug.t.sol
+++ b/test/lib/Permit2DaiBug.t.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+import {Permit2LibWrapper} from "../util/mock/Permit2LibWrapper.sol";
+import {MockDAI} from "../util/mock/MockDAI.sol";
+
+contract Permit2DaiBugTest is Test {
+    Permit2LibWrapper wrapper;
+    MockDAI dai;
+
+    address owner = address(0x1);
+    address spender = address(0x2);
+
+    function setUp() public {
+        wrapper = new Permit2LibWrapper();
+        dai = new MockDAI();
+    }
+
+    function testPermit2SetsUnlimitedAllowance() public {
+        uint256 amount = 50 * 1e18;
+        uint256 deadline = block.timestamp + 1 days;
+
+        assertEq(dai.allowance(owner, spender), 0);
+
+        wrapper.callPermit2(dai, owner, spender, amount, deadline, 0, bytes32(0), bytes32(0));
+
+        assertEq(dai.allowance(owner, spender), type(uint256).max);
+    }
+}

--- a/test/util/mock/MockDAI.sol
+++ b/test/util/mock/MockDAI.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
+import {IDAIPermit} from "permit2/src/interfaces/IDAIPermit.sol";
+
+contract MockDAI is ERC20, IDAIPermit {
+    bytes32 public constant DAI_DOMAIN_SEPARATOR = 0xdbb8cf42e1ecb028be3f3dbc922e1d878b963f411dc388ced501601c60f7c6f7;
+
+    function DOMAIN_SEPARATOR() public pure override returns (bytes32) {
+        return DAI_DOMAIN_SEPARATOR;
+    }
+
+    constructor() ERC20("Dai Stablecoin", "DAI", 18) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function forceApprove(address owner, address spender, uint256 amount) external returns (bool) {
+        allowance[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+        return true;
+    }
+
+    function permit(
+        address holder,
+        address spender,
+        uint256 nonce,
+        uint256 /*expiry*/,
+        bool allowed,
+        uint8 /*v*/,
+        bytes32 /*r*/,
+        bytes32 /*s*/
+    ) external override {
+        require(nonce == nonces[holder], "bad nonce");
+        nonces[holder]++;
+        allowance[holder][spender] = allowed ? type(uint256).max : 0;
+        emit Approval(holder, spender, allowance[holder][spender]);
+    }
+}

--- a/test/util/mock/Permit2LibWrapper.sol
+++ b/test/util/mock/Permit2LibWrapper.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
+import {Permit2Lib} from "permit2/src/libraries/Permit2Lib.sol";
+
+contract Permit2LibWrapper {
+    function callPermit2(
+        ERC20 token,
+        address owner,
+        address spender,
+        uint256 amount,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        Permit2Lib.permit2(token, owner, spender, amount, deadline, v, r, s);
+    }
+}


### PR DESCRIPTION
## Summary
- create `MockDAI` token implementing DAI style permit
- add `Permit2LibWrapper` helper
- test that `Permit2Lib.permit2` grants unlimited allowance when used with DAI

## Testing
- `forge test -vv`

------
https://chatgpt.com/codex/tasks/task_e_687ea009bcb0832dbead04a87f0482db