### PR TITLE
Add failing test for decay curve length mismatch

### DIFF
--- a/test/lib/NonLinearDutchDecayLibBug.t.sol
+++ b/test/lib/NonLinearDutchDecayLibBug.t.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+import {NonlinearDutchDecayLib} from "../../src/lib/NonlinearDutchDecayLib.sol";
+import {CurveBuilder} from "../util/CurveBuilder.sol";
+import {NonlinearDutchDecay} from "../../src/lib/V3DutchOrderLib.sol";
+import {BlockNumberish} from "../../src/base/BlockNumberish.sol";
+import {MockERC20} from "../util/mock/MockERC20.sol";
+import {OutputsBuilder} from "../util/OutputsBuilder.sol";
+import {V3DutchOutput} from "../../src/lib/V3DutchOrderLib.sol";
+
+contract NonlinearDutchDecayLibBugTest is Test, BlockNumberish {
+    MockERC20 token = new MockERC20("T","T",18);
+
+    function testMismatchedBlocksAndAmounts() public {
+        uint16[] memory blocks = new uint16[](2);
+        blocks[0] = 100;
+        blocks[1] = 200;
+        int256[] memory amounts = new int256[](1);
+        amounts[0] = -1 ether;
+        NonlinearDutchDecay memory curve = CurveBuilder.multiPointCurve(blocks, amounts);
+        V3DutchOutput memory output = V3DutchOutput(address(token), 1 ether, curve, address(0), 0, 0);
+        vm.expectRevert(NonlinearDutchDecayLib.InvalidDecayCurve.selector);
+        NonlinearDutchDecayLib.decay(output, 0, _getBlockNumberish());
+    }
+}


### PR DESCRIPTION
## Summary
- add NonlinearDutchDecayLibBugTest to show missing length check for decay curves

## Testing
- `forge test --match-path test/lib/NonLinearDutchDecayLibBug.t.sol -vv`

------
https://chatgpt.com/codex/tasks/task_e_6887c480f5dc832d98ce203571e4fb36