### PR TITLE
Fix NonlinearDutchDecay length mismatch

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -1,0 +1,8 @@
+# Tested Attack Vectors
+
+## 1. Mismatched Nonlinear Dutch Decay arrays
+
+- **Description**: Craft a `NonlinearDutchDecay` struct where `relativeBlocks` encodes more block points than provided in `relativeAmounts`.
+- **Expectation**: The order decoding should revert with `InvalidDecayCurve` instead of silently misbehaving.
+- **Result**: Before patch the library allowed this mismatch and the provided test `NonlinearDutchDecayLibBugTest` failed. After introducing a length check the test passes confirming the bug is fixed.
+

--- a/src/lib/NonlinearDutchDecayLib.sol
+++ b/src/lib/NonlinearDutchDecayLib.sol
@@ -47,6 +47,26 @@ library NonlinearDutchDecayLib {
             revert InvalidDecayCurve();
         }
 
+        // Check that the packed relativeBlocks has the same number of entries as the
+        // relativeAmounts array. Zero is a valid starting block so we must count the
+        // number of non-zero entries after the first element.
+        uint256 packedBlocks = params.curve.relativeBlocks;
+        uint256 blocksLength;
+        if (packedBlocks == 0) {
+            blocksLength = params.curve.relativeAmounts.length == 0 ? 0 : 1;
+        } else {
+            blocksLength = 1;
+            for (uint256 i = 1; i < 16; i++) {
+                if (uint16(packedBlocks >> (i * 16)) == 0) break;
+                unchecked {
+                    ++blocksLength;
+                }
+            }
+        }
+        if (blocksLength != params.curve.relativeAmounts.length) {
+            revert InvalidDecayCurve();
+        }
+
         // handle current block before decay or no decay
         if (params.decayStartBlock >= params.blockNumberish || params.curve.relativeAmounts.length == 0) {
             return params.startAmount.bound(params.minAmount, params.maxAmount);

--- a/test/lib/NonLinearDutchDecayLibBug.t.sol
+++ b/test/lib/NonLinearDutchDecayLibBug.t.sol
@@ -13,6 +13,7 @@ import {V3DutchOutput} from "../../src/lib/V3DutchOrderLib.sol";
 contract NonlinearDutchDecayLibBugTest is Test, BlockNumberish {
     MockERC20 token = new MockERC20("T","T",18);
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testMismatchedBlocksAndAmounts() public {
         uint16[] memory blocks = new uint16[](2);
         blocks[0] = 100;


### PR DESCRIPTION
## Summary
- validate that `relativeBlocks` and `relativeAmounts` have the same length in `NonlinearDutchDecayLib`
- update bug test to expect revert using internal revert capture
- document tested attack vector

## Testing
- `forge test --match-contract NonlinearDutchDecayLibBugTest`
- `forge test --match-contract NonlinearDutchDecayLibTest`
- `forge test --match-contract V3DutchOrderTest`

------
https://chatgpt.com/codex/tasks/task_e_6889264878fc832da603bd7e762db2b9