### PR TITLE
Add zero-output order test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -1,0 +1,8 @@
+# Tested Attack Vectors
+
+This document tracks the security vectors evaluated via unit tests.
+
+## Limit Order With No Outputs
+- **Vector:** Execute a `LimitOrder` where the `outputs` array is empty.
+- **Result:** Order executes successfully, transferring the swapper's input tokens to the filler without providing any output tokens. The absence of validation allows trivial token theft.
+- **Status:** **Bug discovered** – see `testExecuteNoOutputs` in `LimitOrderReactorZeroOutputs.t.sol`.

--- a/snapshots/LimitOrderReactorZeroOutputsTest.json
+++ b/snapshots/LimitOrderReactorZeroOutputsTest.json
@@ -1,0 +1,11 @@
+{
+  "BaseExecuteSingleWithFee": "186484",
+  "ExecuteBatch": "196225",
+  "ExecuteBatchMultipleOutputs": "207301",
+  "ExecuteBatchMultipleOutputsDifferentTokens": "262277",
+  "ExecuteBatchNativeOutput": "190467",
+  "ExecuteSingle": "146795",
+  "ExecuteSingleNativeOutput": "133965",
+  "ExecuteSingleValidation": "159608",
+  "RevertInvalidNonce": "20635"
+}

--- a/test/reactors/LimitOrderReactorZeroOutputs.t.sol
+++ b/test/reactors/LimitOrderReactorZeroOutputs.t.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {LimitOrderReactorTest} from "./LimitOrderReactor.t.sol";
+import {LimitOrder} from "../../src/lib/LimitOrderLib.sol";
+import {OutputToken, InputToken, SignedOrder, OrderInfo} from "../../src/base/ReactorStructs.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+
+contract LimitOrderReactorZeroOutputsTest is LimitOrderReactorTest {
+    using OrderInfoBuilder for OrderInfo;
+
+    function testExecuteNoOutputs() public {
+        tokenIn.forceApprove(swapper, address(permit2), ONE);
+        LimitOrder memory order = LimitOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper),
+            input: InputToken(tokenIn, ONE, ONE),
+            outputs: new OutputToken[](0)
+        });
+        bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
+        // Execute without expecting revert -- order succeeds and transfers input tokens
+        fillContract.execute(SignedOrder(abi.encode(order), sig));
+        // Verify that input tokens were transferred to the filler with no outputs produced
+        assertEq(tokenIn.balanceOf(address(swapper)), 0);
+        assertEq(tokenIn.balanceOf(address(fillContract)), ONE);
+        assertEq(tokenOut.balanceOf(address(swapper)), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- document tested attack vectors
- add unit test showing zero output orders succeed
- add gas snapshot for new test

## Testing
- `FOUNDRY_PROFILE=lite forge test --match-contract LimitOrderReactorZeroOutputsTest -vvv`

------
https://chatgpt.com/codex/tasks/task_e_6889264afd00832dade66a11b59784f6