### PR TITLE
Add DutchOrder zero outputs test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -46,6 +46,11 @@ This document tracks manual fuzzing and unit tests exploring potential vulnerabi
 - **Result:** Order executes successfully, transferring the swapper's input tokens to the filler without providing any output tokens. The absence of validation allows trivial token theft.
 - **Status:** **Bug discovered** – see `testExecuteNoOutputs` in `LimitOrderReactorZeroOutputs.t.sol`.
 
+## Dutch Order With No Outputs
+- **Vector:** Execute a `DutchOrder` where the `outputs` array is empty.
+- **Result:** Order executes successfully, transferring the swapper's input tokens to the filler without providing any output tokens. The absence of validation allows trivial token theft.
+- **Status:** **Bug discovered** – see `testExecuteNoOutputs` in `DutchOrderReactorZeroOutputs.t.sol`.
+
 
 ## Limit Order With No Outputs
 - **Vector:** Execute a `LimitOrder` where the `outputs` array is empty.

--- a/test/reactors/DutchOrderReactorZeroOutputs.t.sol
+++ b/test/reactors/DutchOrderReactorZeroOutputs.t.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {DutchOrderReactorTest} from "./DutchOrderReactor.t.sol";
+import {DutchOrder, DutchInput, DutchOutput} from "../../src/reactors/DutchOrderReactor.sol";
+import {SignedOrder, InputToken, OrderInfo} from "../../src/base/ReactorStructs.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+
+contract DutchOrderReactorZeroOutputsTest is DutchOrderReactorTest {
+    using OrderInfoBuilder for OrderInfo;
+
+    function testExecuteNoOutputs() public {
+        tokenIn.mint(address(swapper), ONE);
+        tokenIn.forceApprove(swapper, address(permit2), ONE);
+        DutchOrder memory order = DutchOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper),
+            decayStartTime: block.timestamp,
+            decayEndTime: block.timestamp,
+            input: DutchInput(tokenIn, ONE, ONE),
+            outputs: new DutchOutput[](0)
+        });
+        bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
+        fillContract.execute(SignedOrder(abi.encode(order), sig));
+        assertEq(tokenIn.balanceOf(address(swapper)), 0);
+        assertEq(tokenIn.balanceOf(address(fillContract)), ONE);
+        assertEq(tokenOut.balanceOf(address(swapper)), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add DutchOrderReactorZeroOutputs test to demonstrate empty outputs vulnerability
- document this new vector in TestedVectors.md

## Testing
- `forge test --match-path test/reactors/DutchOrderReactorZeroOutputs.t.sol --match-test testExecuteNoOutputs -vv`


------
https://chatgpt.com/codex/tasks/task_e_688a6b4b9c78832d930389f8239d4f0c