### PR TITLE
Document unsorted blocks bug

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -88,3 +88,9 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 ## Double Execution Across Reactors
 **Description**: Using a custom fill contract to execute an order on one reactor while triggering execution on a second reactor during the callback.
 **Result**: Existing tests show this succeeds without violating state, demonstrating the contract safely handles separate reactor calls.
+
+## Nonlinear Dutch Order with Unsorted Blocks
+- **Description**: Craft a `NonlinearDutchDecay` curve with `relativeBlocks` that are not strictly increasing.
+- **Test**: `NonlinearDutchDecayLibOutOfOrderTest.testOutOfOrderBlocks` executes such a curve and shows the decay increases to an unexpected amount instead of reverting.
+- **Result**: **Bug discovered** – library accepts out-of-order curves leading to unintuitive decayed values.
+

--- a/test/lib/NonlinearDutchDecayLibOutOfOrder.t.sol
+++ b/test/lib/NonlinearDutchDecayLibOutOfOrder.t.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+import {NonlinearDutchDecayLib} from "../../src/lib/NonlinearDutchDecayLib.sol";
+import {V3DutchOutput, NonlinearDutchDecay} from "../../src/lib/V3DutchOrderLib.sol";
+import {MockERC20} from "../util/mock/MockERC20.sol";
+import {CurveBuilder} from "../util/CurveBuilder.sol";
+import {BlockNumberish} from "../../src/base/BlockNumberish.sol";
+
+contract NonlinearDutchDecayLibOutOfOrderTest is Test, BlockNumberish {
+    MockERC20 token = new MockERC20("T", "T", 18);
+
+    function testOutOfOrderBlocks() public {
+        uint16[] memory blocks = new uint16[](2);
+        blocks[0] = 100;
+        blocks[1] = 50;
+        int256[] memory amounts = new int256[](2);
+        amounts[0] = -1 ether;
+        amounts[1] = -2 ether;
+        NonlinearDutchDecay memory curve = CurveBuilder.multiPointCurve(blocks, amounts);
+        V3DutchOutput memory output = V3DutchOutput(address(token), 3 ether, curve, address(this), 0, 0);
+        vm.roll(150);
+        uint256 decayed = NonlinearDutchDecayLib.decay(output, 0, _getBlockNumberish()).amount;
+        emit log_uint(decayed);
+    }
+}


### PR DESCRIPTION
## Summary
- add failing curve example for NonlinearDutchDecay with out of order blocks
- record this new bug in TestedVectors

## Testing
- `forge test --match-path test/lib/NonlinearDutchDecayLibOutOfOrder.t.sol -vvv`

------
https://chatgpt.com/codex/tasks/task_e_688a6b4b9c78832d930389f8239d4f0c