### PR TITLE
Add priority order zero outputs test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -51,6 +51,13 @@ This document tracks manual fuzzing and unit tests exploring potential vulnerabi
 - **Result:** Order executes successfully, transferring the swapper's input tokens to the filler without providing any output tokens. The absence of validation allows trivial token theft.
 - **Status:** **Bug discovered** – see `testExecuteNoOutputs` in `DutchOrderReactorZeroOutputs.t.sol`.
 
+## Priority Order With No Outputs
+- **Vector:** Execute a `PriorityOrder` where the `outputs` array is empty.
+- **Result:** Order executes successfully, transferring the swapper's input tokens to the filler without providing any output tokens. The absence of validation allows trivial token theft.
+- **Status:** **Bug discovered** – see `testExecuteNoOutputs` in `PriorityOrderReactorZeroOutputs.t.sol`.
+
+
+
 
 ## Limit Order With No Outputs
 - **Vector:** Execute a `LimitOrder` where the `outputs` array is empty.

--- a/snapshots/PriorityOrderReactorZeroOutputsTest.json
+++ b/snapshots/PriorityOrderReactorZeroOutputsTest.json
@@ -1,0 +1,15 @@
+{
+  "BaseExecuteSingleWithFee": "174229",
+  "ExecuteBatch": "185075",
+  "ExecuteBatchMultipleOutputs": "194283",
+  "ExecuteBatchMultipleOutputsDifferentTokens": "247393",
+  "ExecuteBatchNativeOutput": "181115",
+  "ExecuteSingle": "140964",
+  "ExecuteSingleNativeOutput": "129033",
+  "ExecuteSingleValidation": "149962",
+  "InputPriorityFee": "143267",
+  "OutputPriorityFee": "143273",
+  "OutputPriorityFeeAndBaselinePriorityFee": "143273",
+  "OverrideAuctionTargetBlock": "120313",
+  "RevertInvalidNonce": "8844"
+}

--- a/test/reactors/PriorityOrderReactorZeroOutputs.t.sol
+++ b/test/reactors/PriorityOrderReactorZeroOutputs.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {PriorityOrderReactorTest} from "./PriorityOrderReactor.t.sol";
+import {PriorityOrderLib, PriorityOrder, PriorityInput, PriorityOutput, PriorityCosignerData} from "../../src/lib/PriorityOrderLib.sol";
+import {SignedOrder, InputToken, OrderInfo} from "../../src/base/ReactorStructs.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+
+contract PriorityOrderReactorZeroOutputsTest is PriorityOrderReactorTest {
+    using OrderInfoBuilder for OrderInfo;
+    using PriorityOrderLib for PriorityOrder;
+
+    function testExecuteNoOutputs() public {
+        tokenIn.forceApprove(swapper, address(permit2), ONE);
+        PriorityCosignerData memory cosignerData = PriorityCosignerData({auctionTargetBlock: block.number});
+        PriorityOrder memory order = PriorityOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper),
+            cosigner: vm.addr(cosignerPrivateKey),
+            auctionStartBlock: block.number,
+            baselinePriorityFeeWei: 0,
+            input: PriorityInput({token: tokenIn, amount: ONE, mpsPerPriorityFeeWei: 0}),
+            outputs: new PriorityOutput[](0),
+            cosignerData: cosignerData,
+            cosignature: bytes("")
+        });
+        order.cosignature = _cosign(order.hash(), cosignerData);
+        bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
+        fillContract.execute(SignedOrder(abi.encode(order), sig));
+        assertEq(tokenIn.balanceOf(address(swapper)), 0);
+        assertEq(tokenIn.balanceOf(address(fillContract)), ONE);
+        assertEq(tokenOut.balanceOf(address(swapper)), 0);
+    }
+
+    function _cosign(bytes32 orderHash, PriorityCosignerData memory cosignerData) internal view returns (bytes memory sig) {
+        bytes32 msgHash = keccak256(abi.encodePacked(orderHash, block.chainid, abi.encode(cosignerData)));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(cosignerPrivateKey, msgHash);
+        sig = bytes.concat(r, s, bytes1(v));
+    }
+}


### PR DESCRIPTION
## Summary
- test executing a priority order with no outputs
- record the uncovered bug in TestedVectors

## Testing
- `forge test --match-path test/reactors/PriorityOrderReactorZeroOutputs.t.sol -vv`

------
https://chatgpt.com/codex/tasks/task_e_688a8975135c832db4c4752e1bd90795