### PR TITLE
Add ETH refund DoS test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -104,3 +104,8 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Description**: `executeWithCallback` hands `ResolvedOrder` data to the fill contract. We tested whether mutating this memory during the callback could redirect tokens.
 - **Test**: `LimitOrderReactorTamperTest.testCallbackCanModifyOutputs` uses `MockFillContractTamper` to change the output recipient in-place during the callback.
 - **Result**: The modifications do not persist and the order still pays the original recipient, so this vector is safely handled.
+
+## Leftover ETH refund to non-payable filler
+- **Description**: The reactor refunds any ETH balance to the filler after execution. If the filler contract refuses ETH, this refund reverts and halts order execution. An attacker can send ETH to the reactor to block such fillers.
+- **Test**: `EthOutputNoReceiveTest.testRefundToNonPayableReverts` deploys a `MockFillContractNoReceive` without a payable fallback. After sending stray ETH to the reactor, executing an order reverts with `NativeTransferFailed`.
+- **Result**: **Bug discovered** – leftover ETH can be used to grief non-payable fillers.

--- a/test/base/EthOutputNoReceive.t.sol
+++ b/test/base/EthOutputNoReceive.t.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+import {DeployPermit2} from "../util/DeployPermit2.sol";
+import {OrderInfo, SignedOrder} from "../../src/base/ReactorStructs.sol";
+import {DutchOrderReactor, DutchOrder, DutchInput} from "../../src/reactors/DutchOrderReactor.sol";
+import {OutputsBuilder} from "../util/OutputsBuilder.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+import {MockERC20} from "../util/mock/MockERC20.sol";
+import {MockFillContractNoReceive} from "../util/mock/MockFillContractNoReceive.sol";
+import {PermitSignature} from "../util/PermitSignature.sol";
+import {IPermit2} from "permit2/src/interfaces/IPermit2.sol";
+import {CurrencyLibrary, NATIVE} from "../../src/lib/CurrencyLibrary.sol";
+
+contract EthOutputNoReceiveTest is Test, DeployPermit2, PermitSignature {
+    using OrderInfoBuilder for OrderInfo;
+
+    address constant PROTOCOL_FEE_OWNER = address(2);
+    uint256 constant ONE = 1 ether;
+
+    MockERC20 tokenIn;
+    IPermit2 permit2;
+    DutchOrderReactor reactor;
+    MockFillContractNoReceive fillContract;
+    uint256 swapperKey;
+    address swapper;
+
+    function setUp() public {
+        tokenIn = new MockERC20("T", "T", 18);
+        swapperKey = 0x12341234;
+        swapper = vm.addr(swapperKey);
+        permit2 = IPermit2(deployPermit2());
+        reactor = new DutchOrderReactor(permit2, PROTOCOL_FEE_OWNER);
+        fillContract = new MockFillContractNoReceive(address(reactor));
+        tokenIn.forceApprove(swapper, address(permit2), type(uint256).max);
+    }
+
+    function testRefundToNonPayableReverts() public {
+        // deposit stray ETH to reactor
+        address stranger = address(9999);
+        vm.deal(stranger, ONE);
+        vm.prank(stranger);
+        address(reactor).call{value: ONE}("");
+
+        tokenIn.mint(swapper, ONE);
+        DutchOrder memory order = DutchOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(block.timestamp + 100),
+            decayStartTime: block.timestamp,
+            decayEndTime: block.timestamp + 100,
+            input: DutchInput(tokenIn, ONE, ONE),
+            outputs: OutputsBuilder.singleDutch(NATIVE, ONE, ONE, swapper)
+        });
+
+        SignedOrder memory signedOrder = SignedOrder(abi.encode(order), signOrder(swapperKey, address(permit2), order));
+        vm.expectRevert(CurrencyLibrary.NativeTransferFailed.selector);
+        fillContract.execute(signedOrder);
+    }
+}

--- a/test/util/mock/MockFillContractNoReceive.sol
+++ b/test/util/mock/MockFillContractNoReceive.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
+import {CurrencyLibrary} from "../../../src/lib/CurrencyLibrary.sol";
+import {ResolvedOrder, OutputToken, SignedOrder} from "../../../src/base/ReactorStructs.sol";
+import {IReactor} from "../../../src/interfaces/IReactor.sol";
+import {IReactorCallback} from "../../../src/interfaces/IReactorCallback.sol";
+
+/// @notice Fill contract that cannot receive ETH
+contract MockFillContractNoReceive is IReactorCallback {
+    using CurrencyLibrary for address;
+
+    IReactor immutable reactor;
+
+    constructor(address _reactor) {
+        reactor = IReactor(_reactor);
+    }
+
+    function execute(SignedOrder calldata order) external {
+        reactor.executeWithCallback(order, hex"");
+    }
+
+    function reactorCallback(ResolvedOrder[] memory resolvedOrders, bytes memory) external {
+        for (uint256 i = 0; i < resolvedOrders.length; i++) {
+            for (uint256 j = 0; j < resolvedOrders[i].outputs.length; j++) {
+                OutputToken memory output = resolvedOrders[i].outputs[j];
+                if (output.token.isNative()) {
+                    CurrencyLibrary.transferNative(address(reactor), output.amount);
+                } else {
+                    ERC20(output.token).approve(address(reactor), type(uint256).max);
+                }
+            }
+        }
+    }
+
+    receive() external payable {
+        revert("Cannot receive ETH");
+    }
+}


### PR DESCRIPTION
## Summary
- add MockFillContractNoReceive to simulate non-payable fillers
- add EthOutputNoReceive test showing leftover ETH refund reverts
- document the newly discovered vector in TestedVectors.md

## Testing
- `forge test --match-path test/base/EthOutputNoReceive.t.sol -vv`
- `forge test` *(fails: vm.getCode: failed to read from calibur/out and other tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_688a8975135c832db4c4752e1bd90795