### PR TITLE
Add zero recipient output test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -122,3 +122,8 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Description**: The reactor refunds any ETH balance to the filler after execution. If the filler contract refuses ETH, this refund reverts and halts order execution. An attacker can send ETH to the reactor to block such fillers.
 - **Test**: `EthOutputNoReceiveTest.testRefundToNonPayableReverts` deploys a `MockFillContractNoReceive` without a payable fallback. After sending stray ETH to the reactor, executing an order reverts with `NativeTransferFailed`.
 - **Result**: **Bug discovered** – leftover ETH can be used to grief non-payable fillers.
+
+## Zero Recipient Output
+- **Vector:** Execute a `LimitOrder` where the output recipient is the zero address.
+- **Test:** `LimitOrderReactorZeroRecipientTest.testExecuteZeroRecipient` burns the output tokens by sending them to `address(0)`.
+- **Result:** Order executes successfully and tokens are irretrievably sent to the zero address, demonstrating missing validation for recipient addresses.

--- a/snapshots/LimitOrderReactorZeroRecipientTest.json
+++ b/snapshots/LimitOrderReactorZeroRecipientTest.json
@@ -1,0 +1,11 @@
+{
+  "BaseExecuteSingleWithFee": "169390",
+  "ExecuteBatch": "175300",
+  "ExecuteBatchMultipleOutputs": "183830",
+  "ExecuteBatchMultipleOutputsDifferentTokens": "236260",
+  "ExecuteBatchNativeOutput": "171340",
+  "ExecuteSingle": "136118",
+  "ExecuteSingleNativeOutput": "124187",
+  "ExecuteSingleValidation": "145116",
+  "RevertInvalidNonce": "15912"
+}

--- a/test/reactors/LimitOrderReactorZeroRecipient.t.sol
+++ b/test/reactors/LimitOrderReactorZeroRecipient.t.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {LimitOrderReactorTest} from "./LimitOrderReactor.t.sol";
+import {LimitOrder} from "../../src/lib/LimitOrderLib.sol";
+import {OutputToken, InputToken, SignedOrder, OrderInfo} from "../../src/base/ReactorStructs.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+
+contract LimitOrderReactorZeroRecipientTest is LimitOrderReactorTest {
+    using OrderInfoBuilder for OrderInfo;
+
+    function testExecuteZeroRecipient() public {
+        tokenIn.forceApprove(swapper, address(permit2), ONE);
+        OutputToken[] memory outputs = new OutputToken[](1);
+        outputs[0] = OutputToken(address(tokenOut), ONE, address(0));
+        LimitOrder memory order = LimitOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper),
+            input: InputToken(tokenIn, ONE, ONE),
+            outputs: outputs
+        });
+        bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
+        // Execute without expecting revert -- tokens are sent to the zero address
+        fillContract.execute(SignedOrder(abi.encode(order), sig));
+        // Verify that input tokens were transferred to the filler with no outputs produced
+        assertEq(tokenIn.balanceOf(address(swapper)), 0);
+        assertEq(tokenIn.balanceOf(address(fillContract)), ONE);
+        assertEq(tokenOut.balanceOf(address(0)), ONE);
+        assertEq(tokenOut.balanceOf(address(swapper)), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add new test `LimitOrderReactorZeroRecipientTest` showing that outputs can be sent to the zero address
- document the uncovered vector in TestedVectors

## Testing
- `forge test --match-path test/reactors/LimitOrderReactorZeroRecipient.t.sol -vvv`

------
https://chatgpt.com/codex/tasks/task_e_688a9675d8cc832d88e4edb552dce252