### PR TITLE
Add zero input limit order test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -158,3 +158,9 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Vector:** Execute an `ExclusiveDutchOrder` where the `outputs` array is empty.
 - **Result:** Order executes successfully, transferring the swapper's input tokens to the filler without providing any output tokens. The absence of validation allows trivial token theft.
 - **Status:** **Bug discovered** – see `testExecuteNoOutputs` in `ExclusiveDutchOrderReactorZeroOutputs.t.sol`.
+
+
+## Limit Order With Zero Input
+- **Vector:** Execute a `LimitOrder` where the input token is the zero address and amount is zero.
+- **Result:** Order executes and the filler sends output tokens but receives no input because transferring from the zero address succeeds with no effect.
+- **Status:** **Bug discovered** – see `testExecuteZeroInput` in `LimitOrderReactorZeroInput.t.sol`.

--- a/snapshots/LimitOrderReactorZeroInputTest.json
+++ b/snapshots/LimitOrderReactorZeroInputTest.json
@@ -1,0 +1,11 @@
+{
+  "BaseExecuteSingleWithFee": "169390",
+  "ExecuteBatch": "175300",
+  "ExecuteBatchMultipleOutputs": "183830",
+  "ExecuteBatchMultipleOutputsDifferentTokens": "236260",
+  "ExecuteBatchNativeOutput": "171340",
+  "ExecuteSingle": "136118",
+  "ExecuteSingleNativeOutput": "124187",
+  "ExecuteSingleValidation": "145116",
+  "RevertInvalidNonce": "15912"
+}

--- a/test/reactors/LimitOrderReactorZeroInput.t.sol
+++ b/test/reactors/LimitOrderReactorZeroInput.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {LimitOrderReactorTest} from "./LimitOrderReactor.t.sol";
+import {LimitOrder} from "../../src/lib/LimitOrderLib.sol";
+import {OutputsBuilder} from "../util/OutputsBuilder.sol";
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
+import {OutputToken, InputToken, SignedOrder, OrderInfo} from "../../src/base/ReactorStructs.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+import {NATIVE} from "../../src/lib/CurrencyLibrary.sol";
+
+contract LimitOrderReactorZeroInputTest is LimitOrderReactorTest {
+    using OrderInfoBuilder for OrderInfo;
+
+    function testExecuteZeroInput() public {
+        // order specifies zero address as input token
+        LimitOrder memory order = LimitOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper),
+            input: InputToken(ERC20(address(NATIVE)), 0, 0),
+            outputs: OutputsBuilder.single(address(tokenOut), ONE, swapper)
+        });
+        bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
+        // Execute without expecting revert -- filler sends tokens without receiving input
+        fillContract.execute(SignedOrder(abi.encode(order), sig));
+        // verify filler lost tokens and swapper gained them
+        assertEq(tokenOut.balanceOf(address(fillContract)), 0);
+        assertEq(tokenOut.balanceOf(address(swapper)), ONE);
+    }
+}


### PR DESCRIPTION
## Summary
- add test for limit order with zero input token
- document the zero input bug in TestedVectors

## Testing
- `forge test --match-path test/reactors/LimitOrderReactorZeroInput.t.sol -vvv`

------
https://chatgpt.com/codex/tasks/task_e_688ade167580832d8f3b062ad29df2ff