### PR TITLE
Add zero input exploit test for DutchOrder

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -175,3 +175,7 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Vector:** Execute a `LimitOrder` where the input token is the zero address and amount is zero.
 - **Result:** Order executes and the filler sends output tokens but receives no input because transferring from the zero address succeeds with no effect.
 - **Status:** **Bug discovered** – see `testExecuteZeroInput` in `LimitOrderReactorZeroInput.t.sol`.
+## Dutch Order With Zero Input
+- **Vector:** Execute a `DutchOrder` where the input token is the zero address and amount is zero.
+- **Result:** Order executes successfully, transferring output tokens without receiving any input due to the empty token address transfer succeeding.
+- **Status:** **Bug discovered** – see `testExecuteZeroInput` in `DutchOrderReactorZeroInput.t.sol`.

--- a/test/reactors/DutchOrderReactorZeroInput.t.sol
+++ b/test/reactors/DutchOrderReactorZeroInput.t.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {DutchOrderReactorTest} from "./DutchOrderReactor.t.sol";
+import {DutchOrder, DutchInput, DutchOutput} from "../../src/reactors/DutchOrderReactor.sol";
+import {SignedOrder, InputToken, OrderInfo} from "../../src/base/ReactorStructs.sol";
+import {OutputsBuilder} from "../util/OutputsBuilder.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+import {NATIVE} from "../../src/lib/CurrencyLibrary.sol";
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
+
+contract DutchOrderReactorZeroInputTest is DutchOrderReactorTest {
+    using OrderInfoBuilder for OrderInfo;
+
+    function testExecuteZeroInput() public {
+        tokenOut.mint(address(fillContract), ONE);
+        // create order with zero address input token and zero amount
+        DutchOrder memory order = DutchOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper),
+            decayStartTime: block.timestamp,
+            decayEndTime: block.timestamp,
+            input: DutchInput(ERC20(address(NATIVE)), 0, 0),
+            outputs: OutputsBuilder.singleDutch(address(tokenOut), ONE, ONE, swapper)
+        });
+        bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
+        // Execute without revert -- filler sends output tokens without receiving input
+        fillContract.execute(SignedOrder(abi.encode(order), sig));
+        // verify filler lost tokens and swapper gained them
+        assertEq(tokenOut.balanceOf(address(fillContract)), 0);
+        assertEq(tokenOut.balanceOf(address(swapper)), ONE);
+    }
+}


### PR DESCRIPTION
## Summary
- add failing test for DutchOrder with zero input token
- document new attack vector in TestedVectors

## Testing
- `forge test --match-path test/reactors/DutchOrderReactorZeroInput.t.sol -vv`

------
https://chatgpt.com/codex/tasks/task_e_688c13abffec832dbd97da100c6f1d0c