### PR TITLE
Add ERC777 reentrancy test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -185,3 +185,8 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Test:** `test_base_nonceReuseAcrossReactors` in `BaseReactor.t.sol` executes an order on one reactor then attempts to fill another order with the same nonce on a second reactor.
 - **Result:** The second fill reverts with `InvalidNonce`, showing nonces are globally enforced.
 
+
+## Reentrancy via ERC777 token callback
+- **Vector:** Use an ERC777-style token that attempts to reenter a reactor during `transferFrom` via a callback.
+- **Test:** `LimitOrderReactorTokenReentrancyTest.testReentrancyDuringTransferFrom` uses `MockERC777Reentrant` which calls back into the reactor attempting to execute a batch.
+- **Result:** The transaction reverts with `TRANSFER_FROM_FAILED`, showing that reentrancy during token transfer is blocked.

--- a/test/reactors/LimitOrderReactorTokenReentrancy.t.sol
+++ b/test/reactors/LimitOrderReactorTokenReentrancy.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {LimitOrderReactorTest} from "./LimitOrderReactor.t.sol";
+import {MockERC777Reentrant} from "../util/mock/MockERC777Reentrant.sol";
+import {MockFillContractTokenReentrant} from "../util/mock/MockFillContractTokenReentrant.sol";
+import {InputToken, ResolvedOrder, SignedOrder, OrderInfo} from "../../src/base/ReactorStructs.sol";
+import {OutputsBuilder} from "../util/OutputsBuilder.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+
+using OrderInfoBuilder for OrderInfo;
+
+contract LimitOrderReactorTokenReentrancyTest is LimitOrderReactorTest {
+    function testReentrancyDuringTransferFrom() public {
+        MockERC777Reentrant reentrantToken = new MockERC777Reentrant("IN","IN",18);
+        reentrantToken.mint(address(swapper), ONE);
+        reentrantToken.forceApprove(swapper, address(permit2), type(uint256).max);
+
+        MockFillContractTokenReentrant fill = new MockFillContractTokenReentrant(address(reactor));
+        reentrantToken.setCallback(address(fill));
+        tokenOut.mint(address(fill), ONE);
+
+        ResolvedOrder memory order = ResolvedOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(address(swapper)).withDeadline(block.timestamp + 1000),
+            input: InputToken(reentrantToken, ONE, ONE),
+            outputs: OutputsBuilder.single(address(tokenOut), ONE, address(swapper)),
+            sig: hex"",
+            hash: bytes32(0)
+        });
+        (SignedOrder memory signed,) = createAndSignOrder(order);
+
+        vm.expectRevert("TRANSFER_FROM_FAILED");
+        fill.execute(signed);
+    }
+}

--- a/test/util/mock/MockERC777Reentrant.sol
+++ b/test/util/mock/MockERC777Reentrant.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
+
+interface IReenter {
+    function reenter() external;
+}
+
+/// @notice ERC20 that triggers a callback after transferFrom to simulate ERC777 tokens
+contract MockERC777Reentrant is ERC20 {
+    address public callback;
+
+    constructor(string memory name, string memory symbol, uint8 decimals) ERC20(name, symbol, decimals) {}
+
+    function setCallback(address _callback) external {
+        callback = _callback;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function forceApprove(address from, address to, uint256 amount) external returns (bool) {
+        allowance[from][to] = amount;
+        emit Approval(from, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        bool success = super.transferFrom(from, to, amount);
+        if (callback != address(0)) {
+            IReenter(callback).reenter();
+        }
+        return success;
+    }
+}

--- a/test/util/mock/MockFillContractTokenReentrant.sol
+++ b/test/util/mock/MockFillContractTokenReentrant.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {IReactorCallback} from "../../../src/interfaces/IReactorCallback.sol";
+import {IReactor} from "../../../src/interfaces/IReactor.sol";
+import {SignedOrder, ResolvedOrder} from "../../../src/base/ReactorStructs.sol";
+
+/// @notice Fill contract used to test reentrancy via ERC777 token callback
+contract MockFillContractTokenReentrant is IReactorCallback {
+    IReactor immutable reactor;
+
+    constructor(address _reactor) {
+        reactor = IReactor(_reactor);
+    }
+
+    function execute(SignedOrder calldata order) external {
+        reactor.execute(order);
+    }
+
+    /// @notice Called by the token during transferFrom to attempt reentrancy
+    function reenter() external {
+        SignedOrder[] memory empty = new SignedOrder[](0);
+        reactor.executeBatch(empty);
+    }
+
+    function reactorCallback(ResolvedOrder[] calldata, bytes calldata) external {}
+}


### PR DESCRIPTION
## Summary
- add mock ERC777-like token and filler contract
- add test for reentrancy during ERC777 token transfer
- document the reentrancy vector in TestedVectors

## Testing
- `forge test --match-path test/reactors/LimitOrderReactorTokenReentrancy.t.sol -vv`
- `forge test -q` *(fails on fuzz seeds)*

------
https://chatgpt.com/codex/tasks/task_e_688cc5abcca4832da8d75c572e108f12