### PR TITLE
Add test for exclusivity overflow case

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -185,3 +185,8 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Test:** `test_base_nonceReuseAcrossReactors` in `BaseReactor.t.sol` executes an order on one reactor then attempts to fill another order with the same nonce on a second reactor.
 - **Result:** The second fill reverts with `InvalidNonce`, showing nonces are globally enforced.
 
+
+## Exclusivity Override Overflow
+- **Vector:** Provide `exclusivityOverrideBps` equal to `type(uint256).max` when calling `ExclusivityLib.handleExclusiveOverrideTimestamp`.
+- **Test:** `ExclusivityLibOverflowTest.testExclusivityOverrideBpsOverflow` expects an arithmetic overflow revert for this input.
+- **Result:** The library reverts with an arithmetic error, showing overflow protection is in place.

--- a/test/lib/ExclusivityLibOverflow.t.sol
+++ b/test/lib/ExclusivityLibOverflow.t.sol
@@ -1,0 +1,21 @@
+pragma solidity ^0.8.0;
+
+import {Test, stdError} from "forge-std/Test.sol";
+import {MockExclusivityLib} from "../util/mock/MockExclusivityLib.sol";
+import {OutputsBuilder} from "../util/OutputsBuilder.sol";
+import {ResolvedOrder} from "../../src/base/ReactorStructs.sol";
+
+contract ExclusivityLibOverflowTest is Test {
+    MockExclusivityLib exclusivity;
+
+    function setUp() public {
+        exclusivity = new MockExclusivityLib();
+    }
+
+    function testExclusivityOverrideBpsOverflow() public {
+        ResolvedOrder memory order;
+        order.outputs = OutputsBuilder.single(address(1), 1 ether, address(2));
+        vm.expectRevert(stdError.arithmeticError);
+        exclusivity.handleExclusiveOverrideTimestamp(order, address(3), block.timestamp + 1, type(uint256).max);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ExclusivityLibOverflowTest` covering arithmetic overflow when `exclusivityOverrideBps` is extremely large
- document coverage in `TestedVectors.md`

## Testing
- `forge test --match-path test/lib/ExclusivityLibOverflow.t.sol -vv`

------
https://chatgpt.com/codex/tasks/task_e_688cc5abcca4832da8d75c572e108f12