### PR TITLE
Add native input validation test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -207,3 +207,8 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Vector:** Provide `exclusivityOverrideBps` equal to `type(uint256).max` when calling `ExclusivityLib.handleExclusiveOverrideTimestamp`.
 - **Test:** `ExclusivityLibOverflowTest.testExclusivityOverrideBpsOverflow` expects an arithmetic overflow revert for this input.
 - **Result:** The library reverts with an arithmetic error, showing overflow protection is in place.
+
+## Limit Order With Native Input Amount
+- **Vector:** Execute a `LimitOrder` where the input token is the zero address but the amount is non‑zero.
+- **Test:** `LimitOrderReactorNativeInputNonZeroTest.testExecuteNativeInputNonZeroAmount` demonstrates the filler transfers output tokens while receiving no input due to missing validation.
+- **Result:** **Bug discovered** – filler loses tokens because the contract does not reject native input orders.

--- a/test/reactors/LimitOrderReactorNativeInputNonZero.t.sol
+++ b/test/reactors/LimitOrderReactorNativeInputNonZero.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {LimitOrderReactorTest} from "./LimitOrderReactor.t.sol";
+import {LimitOrder} from "../../src/lib/LimitOrderLib.sol";
+import {OutputsBuilder} from "../util/OutputsBuilder.sol";
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
+import {InputToken, SignedOrder, OrderInfo, OutputToken} from "../../src/base/ReactorStructs.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+import {NATIVE} from "../../src/lib/CurrencyLibrary.sol";
+
+contract LimitOrderReactorNativeInputNonZeroTest is LimitOrderReactorTest {
+    using OrderInfoBuilder for OrderInfo;
+
+    function testExecuteNativeInputNonZeroAmount() public {
+        uint256 startBalance = tokenOut.balanceOf(address(fillContract));
+        // create order with native (zero address) input token and non-zero amount
+        LimitOrder memory order = LimitOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper),
+            input: InputToken(ERC20(address(NATIVE)), ONE, ONE),
+            outputs: OutputsBuilder.single(address(tokenOut), ONE, swapper)
+        });
+        bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
+        // filler executes order; call should not revert and filler receives no input
+        fillContract.execute(SignedOrder(abi.encode(order), sig));
+        // verify filler lost output tokens and received no native input
+        assertEq(tokenOut.balanceOf(address(fillContract)), startBalance - ONE);
+        assertEq(tokenOut.balanceOf(address(swapper)), ONE);
+        assertEq(address(fillContract).balance, 0);
+    }
+}


### PR DESCRIPTION
## Summary
- test that limit orders using `NATIVE` as input still execute and cause token loss
- document vector in `TestedVectors.md`

## Testing
- `forge test --match-path test/reactors/LimitOrderReactorNativeInputNonZero.t.sol --match-test testExecuteNativeInputNonZeroAmount -vvv`
- `forge test` *(fails: InvalidCosignature and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_688cfac979ec832d9d1bbc17b0f7eb23