### PR TITLE
Add priority order zero recipient test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -196,6 +196,11 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Test:** `PriorityOrderReactorZeroInputTest.testExecuteZeroInput` demonstrates that the order executes without transferring any input tokens.
 - **Result:** **Bug discovered** – filler provides output tokens while receiving no input due to missing validation.
 
+## Priority Order With Zero Recipient
+- **Vector:** Execute a `PriorityOrder` where an output recipient is the zero address.
+- **Test:** `PriorityOrderReactorZeroRecipientTest.testExecuteZeroRecipient` burns the output tokens by sending them to `address(0)`.
+- **Result:** Order executes successfully and tokens are irretrievably sent to the zero address, showing missing validation.
+
 
 ## Reentrancy via ERC777 token callback
 - **Vector:** Use an ERC777-style token that attempts to reenter a reactor during `transferFrom` via a callback.

--- a/test/reactors/PriorityOrderReactorZeroRecipient.t.sol
+++ b/test/reactors/PriorityOrderReactorZeroRecipient.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {PriorityOrderReactorTest} from "./PriorityOrderReactor.t.sol";
+import {PriorityOrderLib, PriorityOrder, PriorityInput, PriorityOutput, PriorityCosignerData} from "../../src/lib/PriorityOrderLib.sol";
+import {SignedOrder, OrderInfo} from "../../src/base/ReactorStructs.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
+
+contract PriorityOrderReactorZeroRecipientTest is PriorityOrderReactorTest {
+    using OrderInfoBuilder for OrderInfo;
+    using PriorityOrderLib for PriorityOrder;
+
+    function testExecuteZeroRecipient() public {
+        tokenIn.forceApprove(swapper, address(permit2), ONE);
+        PriorityCosignerData memory cosignerData = PriorityCosignerData({auctionTargetBlock: block.number});
+        PriorityOutput[] memory outputs = new PriorityOutput[](1);
+        outputs[0] = PriorityOutput({token: address(tokenOut), amount: ONE, mpsPerPriorityFeeWei: 0, recipient: address(0)});
+        PriorityOrder memory order = PriorityOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper),
+            cosigner: vm.addr(cosignerPrivateKey),
+            auctionStartBlock: block.number,
+            baselinePriorityFeeWei: 0,
+            input: PriorityInput({token: tokenIn, amount: ONE, mpsPerPriorityFeeWei: 0}),
+            outputs: outputs,
+            cosignerData: cosignerData,
+            cosignature: bytes("")
+        });
+        order.cosignature = _cosign(order.hash(), cosignerData);
+        bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
+        fillContract.execute(SignedOrder(abi.encode(order), sig));
+        assertEq(tokenIn.balanceOf(address(swapper)), 0);
+        assertEq(tokenOut.balanceOf(address(swapper)), 0);
+    }
+
+    function _cosign(bytes32 orderHash, PriorityCosignerData memory cosignerData) internal view returns (bytes memory sig) {
+        bytes32 msgHash = keccak256(abi.encodePacked(orderHash, block.chainid, abi.encode(cosignerData)));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(cosignerPrivateKey, msgHash);
+        sig = bytes.concat(r, s, bytes1(v));
+    }
+}


### PR DESCRIPTION
## Summary
- add `PriorityOrderReactorZeroRecipient.t.sol` covering zero recipient
- document the tested vector for priority orders with zero recipients

## Testing
- `forge test --match-path test/reactors/PriorityOrderReactorZeroRecipient.t.sol`


------
https://chatgpt.com/codex/tasks/task_e_688cfac979ec832d9d1bbc17b0f7eb23