### PR TITLE
Add zero-input test for ExclusiveDutchOrder

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -165,6 +165,11 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Result:** Order executes successfully, transferring the swapper's input tokens to the filler without providing any output tokens. The absence of validation allows trivial token theft.
 - **Status:** **Bug discovered** – see `testExecuteNoOutputs` in `ExclusiveDutchOrderReactorZeroOutputs.t.sol`.
 
+## Exclusive Dutch Order With Zero Input
+- **Vector:** Execute an `ExclusiveDutchOrder` where the input token is the zero address and amount is zero.
+- **Test:** `ExclusiveDutchOrderReactorZeroInputTest.testExecuteZeroInput` shows the order executes while the filler provides outputs without receiving any input.
+- **Status:** **Bug discovered** – input validation is missing.
+
 ## UniversalRouterExecutor leftover approvals
 - **Description**: The `UniversalRouterExecutor` permanently approves Permit2 to spend tokens during `reactorCallback`. A malicious router could later drain tokens via Permit2.
 - **Test**: `UniversalRouterExecutorAllowanceAttackTest.testFillerCanDrainApprovedTokens` confirms the approval remains after callback.

--- a/snapshots/ExclusiveDutchOrderReactorZeroInputTest.json
+++ b/snapshots/ExclusiveDutchOrderReactorZeroInputTest.json
@@ -1,0 +1,11 @@
+{
+  "BaseExecuteSingleWithFee": "172197",
+  "ExecuteBatch": "180978",
+  "ExecuteBatchMultipleOutputs": "190309",
+  "ExecuteBatchMultipleOutputsDifferentTokens": "243543",
+  "ExecuteBatchNativeOutput": "177018",
+  "ExecuteSingle": "138932",
+  "ExecuteSingleNativeOutput": "127001",
+  "ExecuteSingleValidation": "147930",
+  "RevertInvalidNonce": "18704"
+}

--- a/test/reactors/ExclusiveDutchOrderReactorZeroInput.t.sol
+++ b/test/reactors/ExclusiveDutchOrderReactorZeroInput.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {ExclusiveDutchOrderReactorTest} from "./ExclusiveDutchOrderReactor.t.sol";
+import {ExclusiveDutchOrder, DutchInput, DutchOutput} from "../../src/reactors/ExclusiveDutchOrderReactor.sol";
+import {SignedOrder, OrderInfo} from "../../src/base/ReactorStructs.sol";
+import {OutputsBuilder} from "../util/OutputsBuilder.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
+import {NATIVE} from "../../src/lib/CurrencyLibrary.sol";
+
+contract ExclusiveDutchOrderReactorZeroInputTest is ExclusiveDutchOrderReactorTest {
+    using OrderInfoBuilder for OrderInfo;
+
+    function testExecuteZeroInput() public {
+        tokenOut.mint(address(fillContract), ONE);
+        ExclusiveDutchOrder memory order = ExclusiveDutchOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper),
+            decayStartTime: block.timestamp,
+            decayEndTime: block.timestamp,
+            exclusiveFiller: address(0),
+            exclusivityOverrideBps: 300,
+            input: DutchInput(ERC20(address(NATIVE)), 0, 0),
+            outputs: OutputsBuilder.singleDutch(address(tokenOut), ONE, ONE, swapper)
+        });
+        bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
+        fillContract.execute(SignedOrder(abi.encode(order), sig));
+        assertEq(tokenOut.balanceOf(address(fillContract)), 0);
+        assertEq(tokenOut.balanceOf(address(swapper)), ONE);
+    }
+}


### PR DESCRIPTION
## Summary
- add ExclusiveDutchOrder zero-input test
- document finding in TestedVectors

## Testing
- `forge test --match-contract ExclusiveDutchOrderReactorZeroInputTest -vv`
- `forge test -q`


------
https://chatgpt.com/codex/tasks/task_e_688cfac979ec832d9d1bbc17b0f7eb23