### PR TITLE
Add priority fee overflow test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -227,3 +227,7 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Vector:** Execute a `PriorityOrder` where an output recipient is the zero address.
 - **Test:** `PriorityOrderReactorZeroRecipientTest.testExecuteZeroRecipient` burns the output tokens by sending them to `address(0)`.
 - **Result:** Order executes successfully and tokens are irretrievably sent to the zero address, showing missing validation.
+\n## Priority Fee Scaling Overflow
+- **Description**: Provide a `PriorityOrder` with `mpsPerPriorityFeeWei` set near `uint256` max so that multiplying by the priority fee would overflow.
+- **Test**: `PriorityOrderOverflowTest.testInputScaleOverflow` sets `mpsPerPriorityFeeWei` to `type(uint256).max` and expects a revert when executing the order.
+- **Result**: No bug – the overflow triggers a revert, so unsafe values cannot be exploited.

--- a/test/PriorityOrderOverflow.t.sol
+++ b/test/PriorityOrderOverflow.t.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {PriorityOrderReactorTest} from "./reactors/PriorityOrderReactor.t.sol";
+import {PriorityOrderLib, PriorityOrder, PriorityInput, PriorityOutput, PriorityCosignerData} from "../src/lib/PriorityOrderLib.sol";
+import {SignedOrder, OrderInfo} from "../src/base/ReactorStructs.sol";
+import {OutputsBuilder} from "./util/OutputsBuilder.sol";
+import {OrderInfoBuilder} from "./util/OrderInfoBuilder.sol";
+
+contract PriorityOrderOverflowTest is PriorityOrderReactorTest {
+    using OrderInfoBuilder for OrderInfo;
+    using PriorityOrderLib for PriorityOrder;
+
+    function testInputScaleOverflow() public {
+        vm.txGasPrice(1000 gwei);
+        PriorityCosignerData memory cosignerData = PriorityCosignerData({auctionTargetBlock: block.number});
+        PriorityOrder memory order = PriorityOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper),
+            cosigner: vm.addr(cosignerPrivateKey),
+            auctionStartBlock: block.number,
+            baselinePriorityFeeWei: 0,
+            input: PriorityInput({token: tokenIn, amount: 1 ether, mpsPerPriorityFeeWei: type(uint256).max}),
+            outputs: OutputsBuilder.singlePriority(address(tokenOut), 1 ether, 0, address(swapper)),
+            cosignerData: cosignerData,
+            cosignature: bytes("")
+        });
+        order.cosignature = _cosign(order.hash(), cosignerData);
+        SignedOrder memory so = SignedOrder(abi.encode(order), signOrder(swapperPrivateKey, address(permit2), order));
+        vm.expectRevert();
+        fillContract.execute(so);
+    }
+
+    function _cosign(bytes32 orderHash, PriorityCosignerData memory cosignerData)
+        private
+        view
+        returns (bytes memory sig)
+    {
+        bytes32 msgHash = keccak256(abi.encodePacked(orderHash, block.chainid, abi.encode(cosignerData)));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(cosignerPrivateKey, msgHash);
+        sig = bytes.concat(r, s, bytes1(v));
+    }
+}


### PR DESCRIPTION
## Summary
- add test ensuring large `mpsPerPriorityFeeWei` values revert instead of overflowing
- document priority fee overflow attempt in TestedVectors

## Testing
- `forge test --match-path test/PriorityOrderOverflow.t.sol -q`

------
https://chatgpt.com/codex/tasks/task_e_688d03927bb4832d9d0fb9a54bf9fbef