### PR TITLE
Add test for large NonlinearDutchDecay blocks

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -227,3 +227,8 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Vector:** Execute a `PriorityOrder` where an output recipient is the zero address.
 - **Test:** `PriorityOrderReactorZeroRecipientTest.testExecuteZeroRecipient` burns the output tokens by sending them to `address(0)`.
 - **Result:** Order executes successfully and tokens are irretrievably sent to the zero address, showing missing validation.
+
+## Nonlinear Dutch Order with Large Relative Block Value
+- **Description**: Provide a `NonlinearDutchDecay` curve where `relativeBlocks` contains a value greater than `uint16.max`.
+- **Test**: `NonlinearDutchDecayLargeBlockTest.testLargeRelativeBlockHandled` crafts such a curve and confirms the library computes a decayed amount without reverting.
+- **Result**: No bug – the curve is accepted and processed normally.

--- a/test/lib/NonlinearDutchDecayLargeBlock.t.sol
+++ b/test/lib/NonlinearDutchDecayLargeBlock.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+import {NonlinearDutchDecayLib} from "../../src/lib/NonlinearDutchDecayLib.sol";
+import {V3DutchOutput, NonlinearDutchDecay} from "../../src/lib/V3DutchOrderLib.sol";
+import {MockERC20} from "../util/mock/MockERC20.sol";
+import {BlockNumberish} from "../../src/base/BlockNumberish.sol";
+
+contract NonlinearDutchDecayLargeBlockTest is Test, BlockNumberish {
+    MockERC20 token = new MockERC20("T", "T", 18);
+
+    function testLargeRelativeBlockHandled() public {
+        // relativeBlocks contains a value larger than uint16.max (70000)
+        uint256 packedBlocks = 70000; // 0x11170
+        int256[] memory amounts = new int256[](2);
+        amounts[0] = -1 ether;
+        amounts[1] = -2 ether;
+        NonlinearDutchDecay memory curve = NonlinearDutchDecay({relativeBlocks: packedBlocks, relativeAmounts: amounts});
+        V3DutchOutput memory output = V3DutchOutput(address(token), 3 ether, curve, address(this), 0, 0);
+        vm.roll(80000);
+        uint256 decayed = NonlinearDutchDecayLib.decay(output, 0, _getBlockNumberish()).amount;
+        assertGt(decayed, 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add `NonlinearDutchDecayLargeBlockTest` to check handling of `relativeBlocks` > uint16 max
- document the vector in `TestedVectors.md`

## Testing
- `forge test --match-test testLargeRelativeBlockHandled -vv`

------
https://chatgpt.com/codex/tasks/task_e_688d03927bb4832d9d0fb9a54bf9fbef