### PR TITLE
Add zero-output dutch order tests

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -227,3 +227,13 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Vector:** Execute a `PriorityOrder` where an output recipient is the zero address.
 - **Test:** `PriorityOrderReactorZeroRecipientTest.testExecuteZeroRecipient` burns the output tokens by sending them to `address(0)`.
 - **Result:** Order executes successfully and tokens are irretrievably sent to the zero address, showing missing validation.
+
+## V2 Dutch Order With No Outputs
+- **Vector:** Execute a `V2DutchOrder` where the `baseOutputs` array is empty.
+- **Test:** `V2DutchOrderReactorZeroOutputsTest.testExecuteNoOutputs` mints input tokens to the swapper and executes the order. The filler receives the input tokens and no outputs are produced.
+- **Result:** **Bug discovered** – the contract lacks validation and transfers the swapper's tokens to the filler without any corresponding outputs.
+
+## V3 Dutch Order With No Outputs
+- **Vector:** Execute a `V3DutchOrder` where the `baseOutputs` array is empty.
+- **Test:** `V3DutchOrderReactorZeroOutputsTest.testExecuteNoOutputs` demonstrates that the filler keeps the input tokens since no outputs are specified.
+- **Result:** **Bug discovered** – orders without outputs execute successfully, allowing trivial theft of the swapper's tokens.

--- a/test/reactors/V2DutchOrderReactorZeroOutputs.t.sol
+++ b/test/reactors/V2DutchOrderReactorZeroOutputs.t.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {V2DutchOrderTest} from "./V2DutchOrderReactor.t.sol";
+import {V2DutchOrder, CosignerData, DutchInput, DutchOutput, V2DutchOrderLib} from "../../src/lib/V2DutchOrderLib.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+import {OrderInfo} from "../../src/base/ReactorStructs.sol";
+
+import {SignedOrder} from "../../src/base/ReactorStructs.sol";
+
+using V2DutchOrderLib for V2DutchOrder;
+
+contract V2DutchOrderReactorZeroOutputsTest is V2DutchOrderTest {
+    using OrderInfoBuilder for OrderInfo;
+
+    function testExecuteNoOutputs() public {
+        tokenIn.mint(address(swapper), ONE);
+        tokenIn.forceApprove(swapper, address(permit2), ONE);
+        CosignerData memory cosignerData = CosignerData({
+            decayStartTime: block.timestamp,
+            decayEndTime: block.timestamp,
+            exclusiveFiller: address(0),
+            exclusivityOverrideBps: 0,
+            inputAmount: 0,
+            outputAmounts: new uint256[](0)
+        });
+        V2DutchOrder memory order = V2DutchOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper),
+            cosigner: vm.addr(cosignerPrivateKey),
+            baseInput: DutchInput(tokenIn, ONE, ONE),
+            baseOutputs: new DutchOutput[](0),
+            cosignerData: cosignerData,
+            cosignature: bytes("")
+        });
+        bytes32 orderHash = order.hash();
+        order.cosignature = _cosign(orderHash, cosignerData);
+        bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
+        fillContract.execute(SignedOrder(abi.encode(order), sig));
+        assertEq(tokenIn.balanceOf(address(swapper)), 0);
+        assertEq(tokenIn.balanceOf(address(fillContract)), ONE);
+    }
+
+    function _cosign(bytes32 orderHash, CosignerData memory cosignerData) private view returns (bytes memory sig) {
+        bytes32 msgHash = keccak256(abi.encodePacked(orderHash, block.chainid, abi.encode(cosignerData)));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(cosignerPrivateKey, msgHash);
+        sig = bytes.concat(r, s, bytes1(v));
+    }
+}

--- a/test/reactors/V3DutchOrderReactorZeroOutputs.t.sol
+++ b/test/reactors/V3DutchOrderReactorZeroOutputs.t.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {V3DutchOrderTest} from "./V3DutchOrderReactor.t.sol";
+import {
+    V3DutchOrder,
+    CosignerData,
+    V3DutchInput,
+    V3DutchOutput,
+    NonlinearDutchDecay,
+    V3DutchOrderLib
+} from "../../src/lib/V3DutchOrderLib.sol";
+import {V3DutchOrderReactor} from "../../src/reactors/V3DutchOrderReactor.sol";
+import {SignedOrder, OrderInfo} from "../../src/base/ReactorStructs.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+import {CurveBuilder} from "../util/CurveBuilder.sol";
+
+contract V3DutchOrderReactorZeroOutputsTest is V3DutchOrderTest {
+    using OrderInfoBuilder for OrderInfo;
+    using V3DutchOrderLib for V3DutchOrder;
+
+    function testExecuteNoOutputs() public {
+        tokenIn.mint(address(swapper), ONE);
+        tokenIn.forceApprove(swapper, address(permit2), ONE);
+        CosignerData memory cosignerData = CosignerData({
+            decayStartBlock: block.number,
+            exclusiveFiller: address(0),
+            exclusivityOverrideBps: 0,
+            inputAmount: 0,
+            outputAmounts: new uint256[](0)
+        });
+        V3DutchOrder memory order = V3DutchOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper),
+            cosigner: vm.addr(cosignerPrivateKey),
+            startingBaseFee: block.basefee,
+            baseInput: V3DutchInput(tokenIn, ONE, CurveBuilder.emptyCurve(), ONE, 0),
+            baseOutputs: new V3DutchOutput[](0),
+            cosignerData: cosignerData,
+            cosignature: bytes("")
+        });
+        bytes32 orderHash = order.hash();
+        order.cosignature = _cosign(orderHash, cosignerData);
+        bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
+        fillContract.execute(SignedOrder(abi.encode(order), sig));
+        assertEq(tokenIn.balanceOf(address(swapper)), 0);
+        assertEq(tokenIn.balanceOf(address(fillContract)), ONE);
+    }
+
+    function _cosign(bytes32 orderHash, CosignerData memory cosignerData) private view returns (bytes memory sig) {
+        bytes32 msgHash = keccak256(abi.encodePacked(orderHash, block.chainid, abi.encode(cosignerData)));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(cosignerPrivateKey, msgHash);
+        sig = bytes.concat(r, s, bytes1(v));
+    }
+}


### PR DESCRIPTION
## Summary
- add tests covering empty `baseOutputs` for V2 and V3 dutch orders
- document uncovered attack vectors in `TestedVectors.md`

## Testing
- `forge test --match-path 'test/reactors/*ZeroOutputs.t.sol' --match-test testExecuteNoOutputs -v`

------
https://chatgpt.com/codex/tasks/task_e_688d03927bb4832d9d0fb9a54bf9fbef