### PR TITLE
Add output token reentrancy test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -247,3 +247,8 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Vector:** Execute a `V3DutchOrder` where the `baseOutputs` array is empty.
 - **Test:** `V3DutchOrderReactorZeroOutputsTest.testExecuteNoOutputs` demonstrates that the filler keeps the input tokens since no outputs are specified.
 - **Result:** **Bug discovered** – orders without outputs execute successfully, allowing trivial theft of the swapper's tokens.
+## ERC777 Output Token Reentrancy
+- **Vector:** Use an ERC777-style token as an order output that attempts to reenter the reactor during `transferFrom` via a callback.
+- **Test:** `LimitOrderReactorOutputTokenReentrancyTest.testReentrancyDuringOutputTransfer` transfers such a token to the filler, which then reenters the reactor.
+- **Result:** The transaction reverts with `TRANSFER_FROM_FAILED`, demonstrating that reentrancy during output transfer is blocked.
+

--- a/test/reactors/LimitOrderReactorExpiredDeadline.t.sol
+++ b/test/reactors/LimitOrderReactorExpiredDeadline.t.sol
@@ -6,7 +6,7 @@ import {LimitOrder} from "../../src/lib/LimitOrderLib.sol";
 import {OutputsBuilder} from "../util/OutputsBuilder.sol";
 import {InputToken, OrderInfo, SignedOrder} from "../../src/base/ReactorStructs.sol";
 import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
-import {SignatureExpired} from "../lib/OrderQuoter.t.sol";
+import {OrderQuoterTest} from "../lib/OrderQuoter.t.sol";
 
 contract LimitOrderReactorExpiredDeadlineTest is LimitOrderReactorTest {
     using OrderInfoBuilder for OrderInfo;
@@ -20,7 +20,7 @@ contract LimitOrderReactorExpiredDeadlineTest is LimitOrderReactorTest {
             outputs: OutputsBuilder.single(address(tokenOut), ONE, swapper)
         });
         bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
-        vm.expectRevert(abi.encodeWithSelector(SignatureExpired.selector, deadline));
+        vm.expectRevert(abi.encodeWithSelector(OrderQuoterTest.SignatureExpired.selector, deadline));
         fillContract.execute(SignedOrder(abi.encode(order), sig));
     }
 }

--- a/test/reactors/LimitOrderReactorOutputTokenReentrancy.t.sol
+++ b/test/reactors/LimitOrderReactorOutputTokenReentrancy.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {LimitOrderReactorTest} from "./LimitOrderReactor.t.sol";
+import {MockERC777Reentrant} from "../util/mock/MockERC777Reentrant.sol";
+import {MockFillContractTokenReentrant} from "../util/mock/MockFillContractTokenReentrant.sol";
+import {InputToken, ResolvedOrder, SignedOrder, OrderInfo} from "../../src/base/ReactorStructs.sol";
+import {OutputsBuilder} from "../util/OutputsBuilder.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+
+using OrderInfoBuilder for OrderInfo;
+
+contract LimitOrderReactorOutputTokenReentrancyTest is LimitOrderReactorTest {
+    function testReentrancyDuringOutputTransfer() public {
+        MockERC777Reentrant reentrantToken = new MockERC777Reentrant("OUT","OUT",18);
+        tokenIn.mint(address(swapper), ONE);
+        tokenIn.forceApprove(swapper, address(permit2), type(uint256).max);
+
+        MockFillContractTokenReentrant fill = new MockFillContractTokenReentrant(address(reactor));
+        reentrantToken.mint(address(fill), ONE);
+        reentrantToken.setCallback(address(fill));
+
+        ResolvedOrder memory order = ResolvedOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(address(swapper)).withDeadline(block.timestamp + 1000),
+            input: InputToken(tokenIn, ONE, ONE),
+            outputs: OutputsBuilder.single(address(reentrantToken), ONE, address(fill)),
+            sig: hex"",
+            hash: bytes32(0)
+        });
+        (SignedOrder memory signed,) = createAndSignOrder(order);
+
+        vm.expectRevert("TRANSFER_FROM_FAILED");
+        fill.execute(signed);
+    }
+}


### PR DESCRIPTION
## Summary
- test ERC777 token reentrancy when used as an output token
- adjust expired deadline test to reference error via `OrderQuoterTest`
- document the new vector in `TestedVectors.md`

## Testing
- `forge test --match-path test/reactors/LimitOrderReactorOutputTokenReentrancy.t.sol --match-test ReentrancyDuringOutputTransfer -vvvv`

------
https://chatgpt.com/codex/tasks/task_e_688d115ecd38832da4a6e97c29ac584e