### PR TITLE
Add DutchOrder native input test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -224,9 +224,16 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Result:** The library reverts with an arithmetic error, showing overflow protection is in place.
 
 ## Limit Order With Native Input Amount
+
+
 - **Vector:** Execute a `LimitOrder` where the input token is the zero address but the amount is non‑zero.
 - **Test:** `LimitOrderReactorNativeInputNonZeroTest.testExecuteNativeInputNonZeroAmount` demonstrates the filler transfers output tokens while receiving no input due to missing validation.
 - **Result:** **Bug discovered** – filler loses tokens because the contract does not reject native input orders.
+## Dutch Order With Native Input Amount
+- **Vector:** Execute a `DutchOrder` where the input token is the zero address and the amount is non-zero.
+- **Test:** `DutchOrderReactorNativeInputNonZeroTest.testExecuteNativeInputNonZeroAmount` expects a revert with `TRANSFER_FROM_FAILED`, showing the invalid native input is rejected.
+- **Result:** No bug – the transaction reverts, so fillers cannot be tricked into losing tokens.
+
 
 ## Priority Order With Zero Recipient
 - **Vector:** Execute a `PriorityOrder` where an output recipient is the zero address.

--- a/test/reactors/DutchOrderReactorNativeInputNonZero.t.sol
+++ b/test/reactors/DutchOrderReactorNativeInputNonZero.t.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {DutchOrderReactorTest} from "./DutchOrderReactor.t.sol";
+import {DutchOrder, DutchInput} from "../../src/lib/DutchOrderLib.sol";
+import {OutputsBuilder} from "../util/OutputsBuilder.sol";
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
+import {InputToken, SignedOrder, OrderInfo} from "../../src/base/ReactorStructs.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+import {NATIVE} from "../../src/lib/CurrencyLibrary.sol";
+
+contract DutchOrderReactorNativeInputNonZeroTest is DutchOrderReactorTest {
+    using OrderInfoBuilder for OrderInfo;
+
+    function testExecuteNativeInputNonZeroAmount() public {
+        uint256 startBalance = tokenOut.balanceOf(address(fillContract));
+        DutchOrder memory order = DutchOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper),
+            decayStartTime: block.timestamp,
+            decayEndTime: block.timestamp,
+            input: DutchInput(ERC20(address(NATIVE)), ONE, ONE),
+            outputs: OutputsBuilder.singleDutch(address(tokenOut), ONE, ONE, swapper)
+        });
+        bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
+        vm.expectRevert("TRANSFER_FROM_FAILED");
+        fillContract.execute(SignedOrder(abi.encode(order), sig));
+        assertEq(tokenOut.balanceOf(address(fillContract)), startBalance);
+        assertEq(tokenOut.balanceOf(address(swapper)), 0);
+    }
+}

--- a/test/reactors/LimitOrderReactorExpiredDeadline.t.sol
+++ b/test/reactors/LimitOrderReactorExpiredDeadline.t.sol
@@ -6,7 +6,7 @@ import {LimitOrder} from "../../src/lib/LimitOrderLib.sol";
 import {OutputsBuilder} from "../util/OutputsBuilder.sol";
 import {InputToken, OrderInfo, SignedOrder} from "../../src/base/ReactorStructs.sol";
 import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
-import {OrderQuoterTest} from "../lib/OrderQuoter.t.sol";
+import {OrderQuoterTest, SignatureExpired} from "../lib/OrderQuoter.t.sol";
 
 contract LimitOrderReactorExpiredDeadlineTest is LimitOrderReactorTest {
     using OrderInfoBuilder for OrderInfo;
@@ -20,7 +20,7 @@ contract LimitOrderReactorExpiredDeadlineTest is LimitOrderReactorTest {
             outputs: OutputsBuilder.single(address(tokenOut), ONE, swapper)
         });
         bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
-        vm.expectRevert(abi.encodeWithSelector(OrderQuoterTest.SignatureExpired.selector, deadline));
+        vm.expectRevert(abi.encodeWithSelector(SignatureExpired.selector, deadline));
         fillContract.execute(SignedOrder(abi.encode(order), sig));
     }
 }


### PR DESCRIPTION
## Summary
- add test that DutchOrder reverts when input token is native and non-zero amount
- document the result in TestedVectors
- fix signature expired import path

## Testing
- `forge test --match-path test/reactors/DutchOrderReactorNativeInputNonZero.t.sol --match-test testExecuteNativeInputNonZeroAmount -q`


------
https://chatgpt.com/codex/tasks/task_e_688d2d56fdec832d9d59f96073c5ea67