### PR TITLE
Fix nonlinear Dutch curve order check

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -102,8 +102,8 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 
 ## Nonlinear Dutch Order with Unsorted Blocks
 - **Description**: Craft a `NonlinearDutchDecay` curve with `relativeBlocks` that are not strictly increasing.
-- **Test**: `NonlinearDutchDecayLibOutOfOrderTest.testOutOfOrderBlocks` executes such a curve and shows the decay increases to an unexpected amount instead of reverting.
-- **Result**: **Bug discovered** – library accepts out-of-order curves leading to unintuitive decayed values.
+- **Test**: `NonlinearDutchDecayLibOutOfOrderTest.testOutOfOrderBlocks` now expects `InvalidDecayCurve` when executing such a curve.
+- **Result**: No bug – the library reverts with `InvalidDecayCurve`, preventing out-of-order curves.
 
 
 ## Callback Order Mutation

--- a/src/lib/NonlinearDutchDecayLib.sol
+++ b/src/lib/NonlinearDutchDecayLib.sol
@@ -56,11 +56,15 @@ library NonlinearDutchDecayLib {
             blocksLength = params.curve.relativeAmounts.length == 0 ? 0 : 1;
         } else {
             blocksLength = 1;
+            uint16 prev = uint16(packedBlocks);
             for (uint256 i = 1; i < 16; i++) {
-                if (uint16(packedBlocks >> (i * 16)) == 0) break;
+                uint16 curr = uint16(packedBlocks >> (i * 16));
+                if (curr == 0) break;
+                if (curr <= prev) revert InvalidDecayCurve();
                 unchecked {
                     ++blocksLength;
                 }
+                prev = curr;
             }
         }
         if (blocksLength != params.curve.relativeAmounts.length) {

--- a/test/lib/NonlinearDutchDecayLibOutOfOrder.t.sol
+++ b/test/lib/NonlinearDutchDecayLibOutOfOrder.t.sol
@@ -21,7 +21,7 @@ contract NonlinearDutchDecayLibOutOfOrderTest is Test, BlockNumberish {
         NonlinearDutchDecay memory curve = CurveBuilder.multiPointCurve(blocks, amounts);
         V3DutchOutput memory output = V3DutchOutput(address(token), 3 ether, curve, address(this), 0, 0);
         vm.roll(150);
-        uint256 decayed = NonlinearDutchDecayLib.decay(output, 0, _getBlockNumberish()).amount;
-        emit log_uint(decayed);
+        vm.expectRevert(NonlinearDutchDecayLib.InvalidDecayCurve.selector);
+        NonlinearDutchDecayLib.decay(output, 0, _getBlockNumberish());
     }
 }


### PR DESCRIPTION
## Summary
- validate that nonlinear Dutch curves are strictly increasing
- update OutOfOrder test to expect revert
- mark unsorted curve vector as handled

## Testing
- `forge test` *(fails: command not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688d2d56fdec832d9d59f96073c5ea67