### PR TITLE
Add exclusive dutch zero recipient test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -266,3 +266,8 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Description**: Attempt to reenter a reactor during `additionalValidationContract.validate`.
 - **Test**: `LimitOrderReactorValidationReentrancyTest.testValidationReentrancy` deploys `MockValidationContractReentrant` which tries to call `execute` inside `validate` using `staticcall`.
 - **Result**: The call fails and the transaction reverts with `"call failed"`, showing the view restriction prevents reentrancy.
+
+## Exclusive Dutch Order With Zero Recipient
+- **Vector:** Execute an `ExclusiveDutchOrder` where an output recipient is the zero address.
+- **Test:** `ExclusiveDutchOrderReactorZeroRecipientTest.testExecuteZeroRecipient` burns the output tokens by sending them to `address(0)`.
+- **Result:** Order executes successfully and tokens are irretrievably sent to the zero address, showing missing validation for recipient addresses.

--- a/test/reactors/ExclusiveDutchOrderReactorZeroRecipient.t.sol
+++ b/test/reactors/ExclusiveDutchOrderReactorZeroRecipient.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {ExclusiveDutchOrderReactorTest} from "./ExclusiveDutchOrderReactor.t.sol";
+import {ExclusiveDutchOrder, DutchInput, DutchOutput} from "../../src/reactors/ExclusiveDutchOrderReactor.sol";
+import {SignedOrder, InputToken, OrderInfo} from "../../src/base/ReactorStructs.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+
+contract ExclusiveDutchOrderReactorZeroRecipientTest is ExclusiveDutchOrderReactorTest {
+    using OrderInfoBuilder for OrderInfo;
+
+    function testExecuteZeroRecipient() public {
+        tokenIn.mint(address(swapper), ONE);
+        tokenIn.forceApprove(swapper, address(permit2), ONE);
+        tokenOut.mint(address(fillContract), ONE);
+        DutchOutput[] memory outputs = new DutchOutput[](1);
+        outputs[0] = DutchOutput(address(tokenOut), ONE, ONE, address(0));
+        ExclusiveDutchOrder memory order = ExclusiveDutchOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper),
+            decayStartTime: block.timestamp,
+            decayEndTime: block.timestamp,
+            exclusiveFiller: address(0),
+            exclusivityOverrideBps: 300,
+            input: DutchInput(tokenIn, ONE, ONE),
+            outputs: outputs
+        });
+        bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
+        // Execute without expecting revert -- tokens are sent to zero address
+        fillContract.execute(SignedOrder(abi.encode(order), sig));
+        assertEq(tokenIn.balanceOf(address(swapper)), 0);
+        assertEq(tokenIn.balanceOf(address(fillContract)), ONE);
+        assertEq(tokenOut.balanceOf(address(0)), ONE);
+        assertEq(tokenOut.balanceOf(address(swapper)), 0);
+    }
+}

--- a/test/reactors/LimitOrderReactorExpiredDeadline.t.sol
+++ b/test/reactors/LimitOrderReactorExpiredDeadline.t.sol
@@ -6,7 +6,7 @@ import {LimitOrder} from "../../src/lib/LimitOrderLib.sol";
 import {OutputsBuilder} from "../util/OutputsBuilder.sol";
 import {InputToken, OrderInfo, SignedOrder} from "../../src/base/ReactorStructs.sol";
 import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
-import {OrderQuoterTest} from "../lib/OrderQuoter.t.sol";
+import {OrderQuoterTest, SignatureExpired} from "../lib/OrderQuoter.t.sol";
 
 contract LimitOrderReactorExpiredDeadlineTest is LimitOrderReactorTest {
     using OrderInfoBuilder for OrderInfo;
@@ -20,7 +20,7 @@ contract LimitOrderReactorExpiredDeadlineTest is LimitOrderReactorTest {
             outputs: OutputsBuilder.single(address(tokenOut), ONE, swapper)
         });
         bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
-        vm.expectRevert(abi.encodeWithSelector(OrderQuoterTest.SignatureExpired.selector, deadline));
+        vm.expectRevert(abi.encodeWithSelector(SignatureExpired.selector, deadline));
         fillContract.execute(SignedOrder(abi.encode(order), sig));
     }
 }


### PR DESCRIPTION
## Summary
- fix compilation of expired deadline test
- document a new tested vector
- add `ExclusiveDutchOrderReactorZeroRecipient` test

## Testing
- `forge test --match-path test/reactors/ExclusiveDutchOrderReactorZeroRecipient.t.sol --match-test testExecuteZeroRecipient -vv`

------
https://chatgpt.com/codex/tasks/task_e_688d2d56fdec832d9d59f96073c5ea67