### PR TITLE
Add expired deadline test for priority orders

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -240,6 +240,11 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Test:** `PriorityOrderReactorZeroRecipientTest.testExecuteZeroRecipient` burns the output tokens by sending them to `address(0)`.
 - **Result:** Order executes successfully and tokens are irretrievably sent to the zero address, showing missing validation.
 
+## Priority Order Expired Deadline
+- **Vector:** Execute a `PriorityOrder` where the `deadline` timestamp has already passed.
+- **Test:** `PriorityOrderReactorExpiredDeadlineTest.testExecuteExpiredDeadline` submits such an order and expects a revert.
+- **Result:** The transaction reverts with `InvalidDeadline`, proving expired orders cannot be filled.
+
 ## Priority Fee Scaling Overflow
 - **Description**: Provide a `PriorityOrder` with `mpsPerPriorityFeeWei` set near `uint256` max so that multiplying by the priority fee would overflow.
 - **Test**: `PriorityOrderOverflowTest.testInputScaleOverflow` sets `mpsPerPriorityFeeWei` to `type(uint256).max` and expects a revert when executing the order.

--- a/test/reactors/PriorityOrderReactorExpiredDeadline.t.sol
+++ b/test/reactors/PriorityOrderReactorExpiredDeadline.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {PriorityOrderReactorTest} from "./PriorityOrderReactor.t.sol";
+import {PriorityOrder, PriorityInput, PriorityOutput, PriorityCosignerData} from "../../src/lib/PriorityOrderLib.sol";
+import {OutputsBuilder} from "../util/OutputsBuilder.sol";
+import {InputToken, OrderInfo, SignedOrder} from "../../src/base/ReactorStructs.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+import {PriorityOrderReactor} from "../../src/reactors/PriorityOrderReactor.sol";
+
+contract PriorityOrderReactorExpiredDeadlineTest is PriorityOrderReactorTest {
+    using OrderInfoBuilder for OrderInfo;
+
+    function testExecuteExpiredDeadline() public {
+        tokenIn.forceApprove(swapper, address(permit2), ONE);
+        uint256 deadline = block.timestamp - 1;
+        PriorityOrder memory order = PriorityOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper).withDeadline(deadline),
+            cosigner: address(0),
+            auctionStartBlock: block.number,
+            baselinePriorityFeeWei: 0,
+            input: PriorityInput(tokenIn, ONE, 0),
+            outputs: OutputsBuilder.singlePriority(address(tokenOut), ONE, 0, swapper),
+            cosignerData: PriorityCosignerData({auctionTargetBlock: 0}),
+            cosignature: bytes("")
+        });
+        bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
+        vm.expectRevert(PriorityOrderReactor.InvalidDeadline.selector);
+        fillContract.execute(SignedOrder(abi.encode(order), sig));
+    }
+}


### PR DESCRIPTION
## Summary
- add PriorityOrderReactorExpiredDeadline.t.sol
- document Priority Order Expired Deadline vector in TestedVectors.md

## Testing
- `forge test --match-test testExecuteExpiredDeadline --match-path test/reactors/PriorityOrderReactorExpiredDeadline.t.sol -vvv`


------
https://chatgpt.com/codex/tasks/task_e_688d37e75254832d802885669620ff02