### PR TITLE
Add memory override test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -281,4 +281,4 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 ## Exclusive Dutch Order With Zero Recipient
 - **Vector:** Execute an `ExclusiveDutchOrder` where an output recipient is the zero address.
 - **Test:** `ExclusiveDutchOrderReactorZeroRecipientTest.testExecuteZeroRecipient` burns the output tokens by sending them to `address(0)`.
-- **Result:** Order executes successfully and tokens are irretrievably sent to the zero address, showing missing validation for recipient addresses.
+- **Result:** Order executes successfully and tokens are irretrievably sent to the zero address, showing missing validation for recipient addresses.\n## V3 Dutch Order Cosigner Output Override Memory\n- **Vector:** Suspected that `_updateWithCosignerAmounts` might not persist cosigner output overrides due to copying to a memory variable.\n- **Test:** `V3DutchOrderOutputOverrideMemoryTest.testOverrideAmountApplied` executes an order with a cosigned output amount higher than the base value.\n- **Result:** The override amount was honored and the filler transferred the expected tokens, so the memory handling is correct.

--- a/test/reactors/V3DutchOrderOutputOverrideMemory.t.sol
+++ b/test/reactors/V3DutchOrderOutputOverrideMemory.t.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+import {DeployPermit2} from "../util/DeployPermit2.sol";
+import {PermitSignature} from "../util/PermitSignature.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+import {OutputsBuilder} from "../util/OutputsBuilder.sol";
+import {ArrayBuilder} from "../util/ArrayBuilder.sol";
+import {V3DutchOrderReactor} from "../../src/reactors/V3DutchOrderReactor.sol";
+import {CosignerData, V3DutchOrder, V3DutchInput, V3DutchOutput, V3DutchOrderLib} from "../../src/lib/V3DutchOrderLib.sol";
+import {CurveBuilder} from "../util/CurveBuilder.sol";
+import {IPermit2} from "permit2/src/interfaces/IPermit2.sol";
+import {MockERC20} from "../util/mock/MockERC20.sol";
+import {MockFillContract} from "../util/mock/MockFillContract.sol";
+import {SignedOrder, OrderInfo} from "../../src/base/ReactorStructs.sol";
+
+// Ensure cosigner output overrides are properly applied and not lost due to memory semantics
+contract V3DutchOrderOutputOverrideMemoryTest is Test, DeployPermit2, PermitSignature {
+    using OrderInfoBuilder for OrderInfo;
+    using V3DutchOrderLib for V3DutchOrder;
+
+    uint256 constant cosignerPrivateKey = 0x99999999;
+    uint256 constant swapperPrivateKey = 0x12341234;
+    address swapper = vm.addr(swapperPrivateKey);
+
+    MockERC20 tokenIn;
+    MockERC20 tokenOut;
+    V3DutchOrderReactor reactor;
+    MockFillContract fillContract;
+    IPermit2 permit2;
+
+    function setUp() public {
+        tokenIn = new MockERC20("In", "IN", 18);
+        tokenOut = new MockERC20("Out", "OUT", 18);
+        permit2 = IPermit2(deployPermit2());
+        reactor = new V3DutchOrderReactor(permit2, address(1));
+        fillContract = new MockFillContract(address(reactor));
+    }
+
+    function testOverrideAmountApplied() public {
+        uint256 baseOutput = 1 ether;
+        uint256 overrideOutput = 1.1 ether;
+        uint256 inputAmount = 1 ether;
+
+        tokenIn.mint(swapper, inputAmount);
+        tokenOut.mint(address(fillContract), overrideOutput);
+        tokenIn.forceApprove(swapper, address(permit2), type(uint256).max);
+
+        CosignerData memory cosignerData = CosignerData({
+            decayStartBlock: block.number,
+            exclusiveFiller: address(0),
+            exclusivityOverrideBps: 0,
+            inputAmount: 0,
+            outputAmounts: ArrayBuilder.fill(1, overrideOutput)
+        });
+
+        V3DutchOrder memory order = V3DutchOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper),
+            cosigner: vm.addr(cosignerPrivateKey),
+            startingBaseFee: block.basefee,
+            baseInput: V3DutchInput(tokenIn, inputAmount, CurveBuilder.emptyCurve(), inputAmount, 0),
+            baseOutputs: OutputsBuilder.singleV3Dutch(
+                address(tokenOut), baseOutput, baseOutput, CurveBuilder.emptyCurve(), swapper
+            ),
+            cosignerData: cosignerData,
+            cosignature: bytes("")
+        });
+        bytes32 orderHash = order.hash();
+        order.cosignature = _cosign(orderHash, cosignerData);
+        SignedOrder memory signedOrder = SignedOrder(abi.encode(order), signOrder(swapperPrivateKey, address(permit2), order));
+
+        fillContract.execute(signedOrder);
+
+        assertEq(tokenOut.balanceOf(swapper), overrideOutput);
+    }
+
+    function _cosign(bytes32 orderHash, CosignerData memory cosignerData) private view returns (bytes memory sig) {
+        bytes32 msgHash = keccak256(abi.encodePacked(orderHash, block.chainid, abi.encode(cosignerData)));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(cosignerPrivateKey, msgHash);
+        sig = bytes.concat(r, s, bytes1(v));
+    }
+}


### PR DESCRIPTION
## Summary
- add test verifying cosigner output overrides persist in V3DutchOrder
- document attempted attack in TestedVectors

## Testing
- `forge test --match-path test/reactors/V3DutchOrderOutputOverrideMemory.t.sol -vv`

------
https://chatgpt.com/codex/tasks/task_e_688d37e75254832d802885669620ff02