### PR TITLE
Add reactor recipient refund test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -297,3 +297,8 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Vector:** Suspected that `_updateWithCosignerAmounts` might not persist cosigner output overrides due to copying to a memory variable.
 - **Test:** `V3DutchOrderOutputOverrideMemoryTest.testOverrideAmountApplied` executes an order with a cosigned output amount higher than the base value.
 - **Result:** The override amount was honored and the filler transferred the expected tokens, so the memory handling is correct.
+
+## Native Output Sent to Reactor
+- **Vector:** Execute a `DutchOrder` where an output uses the native token and designates the reactor itself as the recipient.
+- **Test:** `DutchOrderReactorReactorRecipientTest.testReactorRecipientRefundsFiller` executes such an order. The fill contract deposits ETH during the callback, but `_fill` refunds the reactor balance back to the filler because the recipient equals the reactor.
+- **Result:** Order completes without reverting and the filler receives the ETH meant for the reactor, demonstrating missing validation for the reactor address as an output recipient.

--- a/snapshots/DutchOrderReactorReactorRecipientTest.json
+++ b/snapshots/DutchOrderReactorReactorRecipientTest.json
@@ -1,0 +1,11 @@
+{
+  "BaseExecuteSingleWithFee": "171778",
+  "ExecuteBatch": "180152",
+  "ExecuteBatchMultipleOutputs": "189483",
+  "ExecuteBatchMultipleOutputsDifferentTokens": "242717",
+  "ExecuteBatchNativeOutput": "176192",
+  "ExecuteSingle": "138505",
+  "ExecuteSingleNativeOutput": "126574",
+  "ExecuteSingleValidation": "147503",
+  "RevertInvalidNonce": "18288"
+}

--- a/test/reactors/DutchOrderReactorReactorRecipient.t.sol
+++ b/test/reactors/DutchOrderReactorReactorRecipient.t.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {DutchOrderReactorTest} from "./DutchOrderReactor.t.sol";
+import {DutchOrder, DutchInput, DutchOutput} from "../../src/reactors/DutchOrderReactor.sol";
+import {SignedOrder, InputToken, OrderInfo} from "../../src/base/ReactorStructs.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+import {NATIVE} from "../../src/lib/CurrencyLibrary.sol";
+
+contract DutchOrderReactorReactorRecipientTest is DutchOrderReactorTest {
+    using OrderInfoBuilder for OrderInfo;
+
+    function testReactorRecipientRefundsFiller() public {
+        tokenIn.mint(address(swapper), ONE);
+        tokenIn.forceApprove(swapper, address(permit2), ONE);
+        vm.deal(address(fillContract), ONE);
+
+        DutchOutput[] memory outputs = new DutchOutput[](1);
+        outputs[0] = DutchOutput(NATIVE, ONE, ONE, address(reactor));
+        DutchOrder memory order = DutchOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper),
+            decayStartTime: block.timestamp,
+            decayEndTime: block.timestamp,
+            input: DutchInput(tokenIn, ONE, ONE),
+            outputs: outputs
+        });
+        bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
+
+        uint256 startBalance = address(fillContract).balance;
+        fillContract.execute(SignedOrder(abi.encode(order), sig));
+
+        assertEq(tokenIn.balanceOf(address(swapper)), 0);
+        assertEq(tokenIn.balanceOf(address(fillContract)), ONE);
+        assertEq(address(fillContract).balance, startBalance);
+        assertEq(address(reactor).balance, 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add regression test for native output to reactor
- document attack vector in TestedVectors

## Testing
- `forge test --match-path test/reactors/DutchOrderReactorReactorRecipient.t.sol -vvv`

------
https://chatgpt.com/codex/tasks/task_e_688d403596dc832d99fbd176074e3f9f