### PR TITLE
Add stray ERC20 test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -297,3 +297,8 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Vector:** Suspected that `_updateWithCosignerAmounts` might not persist cosigner output overrides due to copying to a memory variable.
 - **Test:** `V3DutchOrderOutputOverrideMemoryTest.testOverrideAmountApplied` executes an order with a cosigned output amount higher than the base value.
 - **Result:** The override amount was honored and the filler transferred the expected tokens, so the memory handling is correct.
+
+## Leftover ERC20 Tokens
+- **Vector:** Deposit ERC20 tokens directly to a reactor and execute an order to see if the filler can claim them.
+- **Test:** `EthOutputMockFillContractTest.testLeftoverErc20TokensRemain` sends stray tokens to the reactor, then fills an unrelated order.
+- **Result:** No bug – the tokens stay in the reactor after execution rather than being refunded or drained.


### PR DESCRIPTION
## Summary
- test for stray ERC20 remaining in reactor
- document the ERC20 stray token vector

## Testing
- `forge test --match-test testLeftoverErc20TokensRemain -vv`
- `forge test -vv` *(fails: 97 failing tests, 1393 tests succeeded)*

------
https://chatgpt.com/codex/tasks/task_e_688d403596dc832d99fbd176074e3f9f