### PR TITLE
Add ERC20 reactor recipient test

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -303,6 +303,12 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Vector:** Execute a `DutchOrder` where an output uses the native token and designates the reactor itself as the recipient.
 - **Test:** `DutchOrderReactorReactorRecipientTest.testReactorRecipientRefundsFiller` executes such an order. The fill contract deposits ETH during the callback, but `_fill` refunds the reactor balance back to the filler because the recipient equals the reactor.
 - **Result:** Order completes without reverting and the filler receives the ETH meant for the reactor, demonstrating missing validation for the reactor address as an output recipient.
+## ERC20 Output Sent to Reactor
+
+- **Vector:** Execute a `DutchOrder` where an ERC20 output designates the reactor as the recipient.
+- **Test:** `DutchOrderReactorERC20ReactorRecipientTest.testReactorRecipientKeepsERC20` fills such an order. The filler transfers the output token to the reactor and it remains there.
+- **Result:** Order completes and the reactor retains the ERC20 tokens, showing no validation against using the reactor as an output recipient.
+
 
 ## Protocol Fee Injection Persistence
 - **Vector:** Suspected that protocol fee outputs injected during `_prepare` would vanish because each order is copied into a temporary memory variable.

--- a/snapshots/DutchOrderReactorERC20ReactorRecipientTest.json
+++ b/snapshots/DutchOrderReactorERC20ReactorRecipientTest.json
@@ -1,0 +1,11 @@
+{
+  "BaseExecuteSingleWithFee": "171778",
+  "ExecuteBatch": "180152",
+  "ExecuteBatchMultipleOutputs": "189483",
+  "ExecuteBatchMultipleOutputsDifferentTokens": "242717",
+  "ExecuteBatchNativeOutput": "176192",
+  "ExecuteSingle": "138505",
+  "ExecuteSingleNativeOutput": "126574",
+  "ExecuteSingleValidation": "147503",
+  "RevertInvalidNonce": "18288"
+}

--- a/test/reactors/DutchOrderReactorERC20ReactorRecipient.t.sol
+++ b/test/reactors/DutchOrderReactorERC20ReactorRecipient.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {DutchOrderReactorTest} from "./DutchOrderReactor.t.sol";
+import {DutchOrder, DutchInput, DutchOutput} from "../../src/reactors/DutchOrderReactor.sol";
+import {SignedOrder, InputToken, OrderInfo} from "../../src/base/ReactorStructs.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+
+contract DutchOrderReactorERC20ReactorRecipientTest is DutchOrderReactorTest {
+    using OrderInfoBuilder for OrderInfo;
+
+    function testReactorRecipientKeepsERC20() public {
+        tokenIn.mint(address(swapper), ONE);
+        tokenIn.forceApprove(swapper, address(permit2), ONE);
+        tokenOut.mint(address(fillContract), ONE);
+
+        DutchOutput[] memory outputs = new DutchOutput[](1);
+        outputs[0] = DutchOutput(address(tokenOut), ONE, ONE, address(reactor));
+        DutchOrder memory order = DutchOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper),
+            decayStartTime: block.timestamp,
+            decayEndTime: block.timestamp,
+            input: DutchInput(tokenIn, ONE, ONE),
+            outputs: outputs
+        });
+        bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
+
+        fillContract.execute(SignedOrder(abi.encode(order), sig));
+
+        assertEq(tokenIn.balanceOf(address(swapper)), 0);
+        assertEq(tokenIn.balanceOf(address(fillContract)), ONE);
+        assertEq(tokenOut.balanceOf(address(fillContract)), 0);
+        assertEq(tokenOut.balanceOf(address(reactor)), ONE);
+    }
+}


### PR DESCRIPTION
## Summary
- test ERC20 output when recipient is reactor
- document ERC20 output vector in TestedVectors

## Testing
- `forge test --match-path test/reactors/DutchOrderReactorERC20ReactorRecipient.t.sol -vvv`

------
https://chatgpt.com/codex/tasks/task_e_688d4698a5e8832db37bc081b011be6f