### PR TITLE
test: demonstrate native input loss in V2 dutch orders

### DIFF
--- a/TestedVectors.md
+++ b/TestedVectors.md
@@ -241,6 +241,13 @@ We tested whether invoking `OrderQuoter.quote` with a fully signed order could t
 - **Result:** No bug – the transaction reverts, so fillers cannot be tricked into losing tokens.
 
 
+## V2 Dutch Order With Native Input Amount
+- **Severity**: Medium
+- **Description**: Execute a `V2DutchOrder` where the input token is the zero address and the amount is non-zero.
+- **Test**: `V2DutchOrderReactorNativeInputNonZeroTest.testExecuteNativeInputNonZeroAmount` shows the filler transfers output tokens while receiving no input due to missing validation.
+- **Result**: **Bug discovered** – native input orders execute successfully, allowing trivial token loss for the filler.
+
+
 ## Priority Order With Native Input Amount
 - **Severity**: Medium
 - **Description**: Execute a `PriorityOrder` where the input token is the zero address and the amount is non-zero.

--- a/test/reactors/V2DutchOrderReactorNativeInputNonZero.t.sol
+++ b/test/reactors/V2DutchOrderReactorNativeInputNonZero.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import {V2DutchOrderTest} from "./V2DutchOrderReactor.t.sol";
+import {V2DutchOrder, CosignerData, DutchInput, DutchOutput, V2DutchOrderLib} from "../../src/lib/V2DutchOrderLib.sol";
+import {OutputsBuilder} from "../util/OutputsBuilder.sol";
+import {OrderInfoBuilder} from "../util/OrderInfoBuilder.sol";
+import {SignedOrder, OrderInfo} from "../../src/base/ReactorStructs.sol";
+import {ERC20} from "solmate/src/tokens/ERC20.sol";
+import {NATIVE} from "../../src/lib/CurrencyLibrary.sol";
+
+contract V2DutchOrderReactorNativeInputNonZeroTest is V2DutchOrderTest {
+    using OrderInfoBuilder for OrderInfo;
+    using V2DutchOrderLib for V2DutchOrder;
+
+    function testExecuteNativeInputNonZeroAmount() public {
+        tokenOut.mint(address(fillContract), ONE);
+        CosignerData memory cosignerData = CosignerData({
+            decayStartTime: block.timestamp,
+            decayEndTime: block.timestamp,
+            exclusiveFiller: address(0),
+            exclusivityOverrideBps: 0,
+            inputAmount: 0,
+            outputAmounts: new uint256[](1)
+        });
+        V2DutchOrder memory order = V2DutchOrder({
+            info: OrderInfoBuilder.init(address(reactor)).withSwapper(swapper),
+            cosigner: vm.addr(cosignerPrivateKey),
+            baseInput: DutchInput(ERC20(address(NATIVE)), ONE, ONE),
+            baseOutputs: OutputsBuilder.singleDutch(address(tokenOut), ONE, ONE, swapper),
+            cosignerData: cosignerData,
+            cosignature: bytes("")
+        });
+        bytes32 orderHash = order.hash();
+        order.cosignature = _cosign(orderHash, cosignerData);
+        bytes memory sig = signOrder(swapperPrivateKey, address(permit2), order);
+        uint256 startBalance = tokenOut.balanceOf(address(fillContract));
+        fillContract.execute(SignedOrder(abi.encode(order), sig));
+        // filler loses output tokens and receives no native input
+        assertEq(tokenOut.balanceOf(address(fillContract)), startBalance - ONE);
+        assertEq(tokenOut.balanceOf(address(swapper)), ONE);
+        assertEq(address(fillContract).balance, 0);
+    }
+
+    function _cosign(bytes32 orderHash, CosignerData memory cosignerData) private view returns (bytes memory sig) {
+        bytes32 msgHash = keccak256(abi.encodePacked(orderHash, block.chainid, abi.encode(cosignerData)));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(cosignerPrivateKey, msgHash);
+        sig = bytes.concat(r, s, bytes1(v));
+    }
+}


### PR DESCRIPTION
## Summary
- add regression test showing V2DutchOrderReactor lets non-zero native input orders execute and drain filler tokens
- record this vector in TestedVectors.md

## Testing
- `forge test --match-contract V2DutchOrderReactorNativeInputNonZeroTest -v` *(fails: many InvalidCosignature and log mismatch errors)*
- `forge test --match-test testExecuteNativeInputNonZeroAmount -v`


------
https://chatgpt.com/codex/tasks/task_e_6892354f9784832dbd78a2418b9397c8